### PR TITLE
WIP: Error handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 - Rename `Histogram::from_vec` to `Histogram::from_slice`.
 - Rename `view::View` to `view::ContinuousView` and introduce `view::View` as a trait.
 - Change `svg_render` functions to take data slices rather than Representations.
+- Add `Result` return types to lots of functions
 
 ## 0.3.0 - 2018-03-01
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ travis-ci = { repository = "milliams/plotlib" }
 
 [dependencies]
 svg = "0.5.10"
+failure = "0.1.1"

--- a/examples/boxplot_svg.rs
+++ b/examples/boxplot_svg.rs
@@ -1,8 +1,9 @@
 extern crate plotlib;
 
 use plotlib::style::BoxPlot;
+use plotlib::Result;
 
-fn main() {
+fn main() -> Result<()> {
     let b1 = plotlib::boxplot::BoxPlot::from_slice(&[1.0, 4.0, 2.0, 3.5, 6.4, 2.5, 7.5, 1.8, 9.6])
         .label("1");
     let b2 = plotlib::boxplot::BoxPlot::from_slice(&[3.0, 4.3, 2.0, 3.5, 6.9, 4.5, 7.5, 1.8, 10.6])
@@ -12,5 +13,5 @@ fn main() {
         .add(&b1)
         .add(&b2)
         .x_label("Experiment");
-    plotlib::page::Page::single(&v).save("boxplot.svg");
+    plotlib::page::Page::single(&v).save("boxplot.svg")
 }

--- a/examples/function_svg.rs
+++ b/examples/function_svg.rs
@@ -1,8 +1,9 @@
 extern crate plotlib;
 
 use plotlib::style::Line;
+use plotlib::Result;
 
-fn main() {
+fn main() -> Result<()> {
     let f1 = plotlib::function::Function::new(|x| x * 5., 0., 10.)
         .style(plotlib::function::Style::new().colour("burlywood"));
     let f2 = plotlib::function::Function::new(|x| x.powi(2), 0., 10.).style(
@@ -16,5 +17,5 @@ fn main() {
         .add(&f1)
         .add(&f2)
         .add(&f3);
-    plotlib::page::Page::single(&v).save("function.svg");
+    plotlib::page::Page::single(&v).save("function.svg")
 }

--- a/examples/histogram_svg.rs
+++ b/examples/histogram_svg.rs
@@ -1,11 +1,13 @@
 extern crate plotlib;
 
 use plotlib::style::Bar;
+use plotlib::Result;
 
-fn main() {
+fn main() -> Result<()> {
     let data = [0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
-    let h = plotlib::histogram::Histogram::from_slice(&data, 10)
+    let h = plotlib::histogram::Histogram::from_slice(&data, 10)?
         .style(plotlib::histogram::Style::new().fill("burlywood"));
     let v = plotlib::view::ContinuousView::new().add(&h);
     plotlib::page::Page::single(&v).save("histogram.svg");
+    Ok(())
 }

--- a/examples/histogram_svg.rs
+++ b/examples/histogram_svg.rs
@@ -8,6 +8,5 @@ fn main() -> Result<()> {
     let h = plotlib::histogram::Histogram::from_slice(&data, 10)?
         .style(plotlib::histogram::Style::new().fill("burlywood"));
     let v = plotlib::view::ContinuousView::new().add(&h);
-    plotlib::page::Page::single(&v).save("histogram.svg");
-    Ok(())
+    plotlib::page::Page::single(&v).save("histogram.svg")
 }

--- a/examples/histogram_text.rs
+++ b/examples/histogram_text.rs
@@ -1,8 +1,9 @@
 extern crate plotlib;
 
-fn main() {
+fn main() -> plotlib::Result<()> {
     let data = [0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
-    let h = plotlib::histogram::Histogram::from_slice(&data, 10);
+    let h = plotlib::histogram::Histogram::from_slice(&data, 10)?;
     let v = plotlib::view::ContinuousView::new().add(&h);
-    println!("{}", plotlib::page::Page::single(&v).to_text());
+    println!("{}", plotlib::page::Page::single(&v).to_text()?);
+    Ok(())
 }

--- a/examples/line_svg.rs
+++ b/examples/line_svg.rs
@@ -1,10 +1,11 @@
 extern crate plotlib;
 
 use plotlib::style::Line;
+use plotlib::Result;
 
-fn main() {
+fn main() -> Result<()> {
     let l1 = plotlib::line::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
         .style(plotlib::line::Style::new().colour("burlywood"));
     let v = plotlib::view::ContinuousView::new().add(&l1);
-    plotlib::page::Page::single(&v).save("line.svg");
+    plotlib::page::Page::single(&v).save("line.svg")
 }

--- a/examples/scatter_svg.rs
+++ b/examples/scatter_svg.rs
@@ -1,8 +1,9 @@
 extern crate plotlib;
 
 use plotlib::style::Point;
+use plotlib::Result;
 
-fn main() {
+fn main() -> Result<()> {
     let data = [
         (-3.0, 2.3),
         (-1.6, 5.3),
@@ -28,7 +29,7 @@ fn main() {
         .unwrap()
         .x_label("Some varying variable")
         .y_label("The response of something");
-    plotlib::page::Page::single(&v).save("scatter.svg");
+    plotlib::page::Page::single(&v).save("scatter.svg")
 
     /*
     //

--- a/examples/scatter_svg.rs
+++ b/examples/scatter_svg.rs
@@ -23,7 +23,9 @@ fn main() {
         .add(&s1)
         .add(&s2)
         .x_range(-5., 10.)
+        .unwrap()
         .y_range(-2., 6.)
+        .unwrap()
         .x_label("Some varying variable")
         .y_label("The response of something");
     plotlib::page::Page::single(&v).save("scatter.svg");

--- a/examples/scatter_text.rs
+++ b/examples/scatter_text.rs
@@ -18,8 +18,10 @@ fn main() {
         .add(&s1)
         .add(&s2)
         .x_range(-5., 10.)
+        .unwrap()
         .y_range(-2., 6.)
+        .unwrap()
         .x_label("Some varying variable")
         .y_label("The response of something");
-    println!("{}", plotlib::page::Page::single(&v).to_text());
+    println!("{}", plotlib::page::Page::single(&v).to_text().unwrap());
 }

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -4,6 +4,9 @@ A module for managing axes
 
 */
 
+use errors::Result;
+use failure::ResultExt;
+
 #[derive(Debug, Clone)]
 pub struct Range {
     pub lower: f64,
@@ -11,12 +14,15 @@ pub struct Range {
 }
 
 impl Range {
-    pub fn new(lower: f64, upper: f64) -> Range {
-        assert!(lower < upper);
-        Range {
+    pub fn new(lower: f64, upper: f64) -> Result<Range> {
+        if lower >= upper {
+            bail!("data ranges give inverted values, {} < {}", lower, upper);
+        }
+
+        Ok(Range {
             lower: lower,
             upper: upper,
-        }
+        })
     }
 }
 
@@ -29,13 +35,13 @@ pub struct ContinuousAxis {
 
 impl ContinuousAxis {
     /// Constructs a new ContinuousAxis
-    pub fn new(lower: f64, upper: f64) -> ContinuousAxis {
+    pub fn new(lower: f64, upper: f64) -> Result<ContinuousAxis> {
         let default_max_ticks = 6;
-        ContinuousAxis {
-            range: Range::new(lower, upper),
+        Ok(ContinuousAxis {
+            range: Range::new(lower, upper).context("creating a new ContinuousAxis")?,
             ticks: calculate_ticks(lower, upper, default_max_ticks),
             label: "".into(),
-        }
+        })
     }
 
     pub fn max(&self) -> f64 {

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -270,11 +270,15 @@ mod tests {
     #[test]
     fn test_calculate_ticks() {
         macro_rules! assert_approx_eq {
-            ($a:expr, $b:expr) => ({
+            ($a:expr, $b:expr) => {{
                 let (a, b) = (&$a, &$b);
-                assert!((*a - *b).abs() < 1.0e-6,
-                        "{} is not approximately equal to {}", *a, *b);
-            })
+                assert!(
+                    (*a - *b).abs() < 1.0e-6,
+                    "{} is not approximately equal to {}",
+                    *a,
+                    *b
+                );
+            }};
         }
 
         for (prod, want) in calculate_ticks(0.0, 1.0, 6)

--- a/src/boxplot.rs
+++ b/src/boxplot.rs
@@ -19,8 +19,8 @@ use svg;
 
 use axis;
 use representation::DiscreteRepresentation;
-use svg_render;
 use style;
+use svg_render;
 use utils;
 
 #[derive(Debug, Default)]
@@ -149,10 +149,10 @@ impl<'a> DiscreteRepresentation for BoxPlot<'a> {
 
     fn to_text(
         &self,
-        x_axis: &axis::DiscreteAxis,
-        y_axis: &axis::ContinuousAxis,
-        face_width: u32,
-        face_height: u32,
+        _x_axis: &axis::DiscreteAxis,
+        _y_axis: &axis::ContinuousAxis,
+        _face_width: u32,
+        _face_height: u32,
     ) -> String {
         "".into()
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,4 @@
+use failure;
+use std::result;
+
+pub type Result<T> = result::Result<T, failure::Error>;

--- a/src/function.rs
+++ b/src/function.rs
@@ -145,15 +145,15 @@ impl ContinuousRepresentation for Function {
         y_axis: &axis::ContinuousAxis,
         face_width: f64,
         face_height: f64,
-    ) -> svg::node::element::Group {
-        svg_render::draw_face_line(
+    ) -> Result<svg::node::element::Group> {
+        Ok(svg_render::draw_face_line(
             &self.data,
             x_axis,
             y_axis,
             face_width,
             face_height,
             &self.style,
-        )
+        ))
     }
 
     fn to_text(
@@ -162,7 +162,7 @@ impl ContinuousRepresentation for Function {
         _y_axis: &axis::ContinuousAxis,
         _face_width: u32,
         _face_height: u32,
-    ) -> String {
-        "".into()
+    ) -> Result<String> {
+        Ok("".into())
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -18,6 +18,7 @@ use std::f64;
 use svg;
 
 use axis;
+use errors::Result;
 use representation::ContinuousRepresentation;
 use style;
 use svg_render;
@@ -108,29 +109,29 @@ impl Function {
         &self.style
     }
 
-    fn x_range(&self) -> (f64, f64) {
+    fn x_range(&self) -> Result<(f64, f64)> {
         let mut min = f64::INFINITY;
         let mut max = f64::NEG_INFINITY;
         for &(x, _) in &self.data {
             min = min.min(x);
             max = max.max(x);
         }
-        (min, max)
+        Ok((min, max))
     }
 
-    fn y_range(&self) -> (f64, f64) {
+    fn y_range(&self) -> Result<(f64, f64)> {
         let mut min = f64::INFINITY;
         let mut max = f64::NEG_INFINITY;
         for &(_, y) in &self.data {
             min = min.min(y);
             max = max.max(y);
         }
-        (min, max)
+        Ok((min, max))
     }
 }
 
 impl ContinuousRepresentation for Function {
-    fn range(&self, dim: u32) -> (f64, f64) {
+    fn range(&self, dim: u32) -> Result<(f64, f64)> {
         match dim {
             0 => self.x_range(),
             1 => self.y_range(),

--- a/src/function.rs
+++ b/src/function.rs
@@ -19,8 +19,8 @@ use svg;
 
 use axis;
 use representation::ContinuousRepresentation;
-use svg_render;
 use style;
+use svg_render;
 
 #[derive(Debug, Default)]
 pub struct Style {
@@ -157,10 +157,10 @@ impl ContinuousRepresentation for Function {
 
     fn to_text(
         &self,
-        x_axis: &axis::ContinuousAxis,
-        y_axis: &axis::ContinuousAxis,
-        face_width: u32,
-        face_height: u32,
+        _x_axis: &axis::ContinuousAxis,
+        _y_axis: &axis::ContinuousAxis,
+        _face_width: u32,
+        _face_height: u32,
     ) -> String {
         "".into()
     }

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -23,11 +23,11 @@ TODO:
 use svg;
 
 use axis;
-use utils::PairWise;
-use svg_render;
-use text_render;
 use representation::ContinuousRepresentation;
 use style;
+use svg_render;
+use text_render;
+use utils::PairWise;
 
 #[derive(Debug, Default)]
 pub struct Style {

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -172,8 +172,8 @@ impl ContinuousRepresentation for Histogram {
         y_axis: &axis::ContinuousAxis,
         face_width: f64,
         face_height: f64,
-    ) -> svg::node::element::Group {
-        svg_render::draw_face_bars(self, x_axis, y_axis, face_width, face_height, &self.style)
+    ) -> Result<svg::node::element::Group> {
+        Ok(svg_render::draw_face_bars(self, x_axis, y_axis, face_width, face_height, &self.style))
     }
 
     fn to_text(
@@ -182,7 +182,7 @@ impl ContinuousRepresentation for Histogram {
         y_axis: &axis::ContinuousAxis,
         face_width: u32,
         face_height: u32,
-    ) -> String {
+    ) -> Result<String> {
         text_render::render_face_bars(self, x_axis, y_axis, face_width, face_height)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,17 +77,17 @@ in this case, interpreting the bins and colours to create SVG elements.
 
 extern crate svg;
 
+pub mod page;
 pub mod representation;
 pub mod view;
-pub mod page;
 
-pub mod histogram;
-pub mod scatter;
-pub mod function;
-pub mod line;
-pub mod style;
-pub mod boxplot;
 mod axis;
-mod utils;
-mod text_render;
+pub mod boxplot;
+pub mod function;
+pub mod histogram;
+pub mod line;
+pub mod scatter;
+pub mod style;
 mod svg_render;
+mod text_render;
+mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ in this case, interpreting the bins and colours to create SVG elements.
 */
 
 extern crate svg;
+#[macro_use]
+extern crate failure;
 
 pub mod page;
 pub mod representation;
@@ -83,6 +85,7 @@ pub mod view;
 
 mod axis;
 pub mod boxplot;
+mod errors;
 pub mod function;
 pub mod histogram;
 pub mod line;
@@ -91,3 +94,5 @@ pub mod style;
 mod svg_render;
 mod text_render;
 mod utils;
+
+pub use errors::Result;

--- a/src/line.rs
+++ b/src/line.rs
@@ -19,8 +19,8 @@ use svg;
 
 use axis;
 use representation::ContinuousRepresentation;
-use svg_render;
 use style;
+use svg_render;
 
 #[derive(Debug, Default)]
 pub struct Style {
@@ -144,10 +144,10 @@ impl ContinuousRepresentation for Line {
 
     fn to_text(
         &self,
-        x_axis: &axis::ContinuousAxis,
-        y_axis: &axis::ContinuousAxis,
-        face_width: u32,
-        face_height: u32,
+        _x_axis: &axis::ContinuousAxis,
+        _y_axis: &axis::ContinuousAxis,
+        _face_width: u32,
+        _face_height: u32,
     ) -> String {
         "".into()
     }

--- a/src/line.rs
+++ b/src/line.rs
@@ -18,6 +18,7 @@ use std::f64;
 use svg;
 
 use axis;
+use errors::Result;
 use representation::ContinuousRepresentation;
 use style;
 use svg_render;
@@ -95,29 +96,29 @@ impl Line {
         &self.style
     }
 
-    fn x_range(&self) -> (f64, f64) {
+    fn x_range(&self) -> Result<(f64, f64)> {
         let mut min = f64::INFINITY;
         let mut max = f64::NEG_INFINITY;
         for &(x, _) in &self.data {
             min = min.min(x);
             max = max.max(x);
         }
-        (min, max)
+        Ok((min, max))
     }
 
-    fn y_range(&self) -> (f64, f64) {
+    fn y_range(&self) -> Result<(f64, f64)> {
         let mut min = f64::INFINITY;
         let mut max = f64::NEG_INFINITY;
         for &(_, y) in &self.data {
             min = min.min(y);
             max = max.max(y);
         }
-        (min, max)
+        Ok((min, max))
     }
 }
 
 impl ContinuousRepresentation for Line {
-    fn range(&self, dim: u32) -> (f64, f64) {
+    fn range(&self, dim: u32) -> Result<(f64, f64)> {
         match dim {
             0 => self.x_range(),
             1 => self.y_range(),

--- a/src/line.rs
+++ b/src/line.rs
@@ -132,15 +132,15 @@ impl ContinuousRepresentation for Line {
         y_axis: &axis::ContinuousAxis,
         face_width: f64,
         face_height: f64,
-    ) -> svg::node::element::Group {
-        svg_render::draw_face_line(
+    ) -> Result<svg::node::element::Group> {
+        Ok(svg_render::draw_face_line(
             &self.data,
             x_axis,
             y_axis,
             face_width,
             face_height,
             &self.style,
-        )
+        ))
     }
 
     fn to_text(
@@ -149,7 +149,7 @@ impl ContinuousRepresentation for Line {
         _y_axis: &axis::ContinuousAxis,
         _face_width: u32,
         _face_height: u32,
-    ) -> String {
-        "".into()
+    ) -> Result<String> {
+        Ok("".into())
     }
 }

--- a/src/page.rs
+++ b/src/page.rs
@@ -5,9 +5,12 @@ The `page` module provides structures for laying out and rendering multiple view
 use std::ffi::OsStr;
 use std::path::Path;
 
+use errors::Result;
 use svg;
 use svg::Document;
 use svg::Node;
+
+use failure::ResultExt;
 
 use view::View;
 
@@ -29,21 +32,22 @@ impl<'a> Page<'a> {
     /**
     Render the plot to an svg document
     */
-    pub fn to_svg(&self) -> svg::Document {
+    pub fn to_svg(&self) -> Result<svg::Document> {
         let mut document = Document::new().set("viewBox", (0, 0, 600, 400));
         // TODO put multiple views in correct places
         for &view in &self.views {
             let view_group = view.to_svg(500., 340.)
+                .context("creating an svg")?
                 .set("transform", format!("translate({}, {})", 50, 360));
             document.append(view_group);
         }
-        document
+        Ok(document)
     }
 
     /**
     Render the plot to an `String`
     */
-    pub fn to_text(&self) -> String {
+    pub fn to_text(&self) -> Result<String> {
         // TODO compose multiple views into a plot
         let view = self.views[0];
         view.to_text(90, 30)
@@ -55,17 +59,19 @@ impl<'a> Page<'a> {
     The type of file will be based on the file extension.
     */
 
-    pub fn save<P>(&self, path: P)
+    pub fn save<P>(&self, path: P) -> Result<()>
     where
         P: AsRef<Path>,
     {
         match path.as_ref().extension().and_then(OsStr::to_str) {
             Some("svg") => {
-                svg::save(path, &self.to_svg()).unwrap();
+                svg::save(path, &self.to_svg().context("saving plot")?).unwrap();
             }
             _ => {
                 // some default
             }
         }
+
+        Ok(())
     }
 }

--- a/src/page.rs
+++ b/src/page.rs
@@ -2,12 +2,12 @@
 The `page` module provides structures for laying out and rendering multiple views.
 */
 
-use std::path::Path;
 use std::ffi::OsStr;
+use std::path::Path;
 
 use svg;
-use svg::Node;
 use svg::Document;
+use svg::Node;
 
 use view::View;
 
@@ -16,7 +16,6 @@ A single page page laying out the views in a grid
 */
 pub struct Page<'a> {
     views: Vec<&'a View>,
-    num_views: u32,
 }
 
 impl<'a> Page<'a> {
@@ -24,10 +23,7 @@ impl<'a> Page<'a> {
     Creates a plot containing a single view
     */
     pub fn single(view: &'a View) -> Self {
-        Page {
-            views: vec![view],
-            num_views: 1,
-        }
+        Page { views: vec![view] }
     }
 
     /**

--- a/src/page.rs
+++ b/src/page.rs
@@ -65,7 +65,7 @@ impl<'a> Page<'a> {
     {
         match path.as_ref().extension().and_then(OsStr::to_str) {
             Some("svg") => {
-                svg::save(path, &self.to_svg().context("saving plot")?).unwrap();
+                svg::save(path, &self.to_svg().context("saving plot")?)?;
             }
             _ => {
                 // some default

--- a/src/representation.rs
+++ b/src/representation.rs
@@ -12,8 +12,8 @@ These points may then be layered with other SVG elements from other representati
 `view::View`.
 */
 
-use svg;
 use axis;
+use svg;
 
 /**
 A representation of data that is continuous in two dimensions.

--- a/src/representation.rs
+++ b/src/representation.rs
@@ -13,6 +13,7 @@ These points may then be layered with other SVG elements from other representati
 */
 
 use axis;
+use errors::Result;
 use svg;
 
 /**
@@ -20,7 +21,7 @@ A representation of data that is continuous in two dimensions.
 */
 pub trait ContinuousRepresentation {
     /// The maximum range in each dimension. Used for auto-scaling axes.
-    fn range(&self, dim: u32) -> (f64, f64);
+    fn range(&self, dim: u32) -> Result<(f64, f64)>;
 
     fn to_svg(
         &self,

--- a/src/representation.rs
+++ b/src/representation.rs
@@ -29,7 +29,7 @@ pub trait ContinuousRepresentation {
         y_axis: &axis::ContinuousAxis,
         face_width: f64,
         face_height: f64,
-    ) -> svg::node::element::Group;
+    ) -> Result<svg::node::element::Group>;
 
     fn to_text(
         &self,
@@ -37,7 +37,7 @@ pub trait ContinuousRepresentation {
         y_axis: &axis::ContinuousAxis,
         face_width: u32,
         face_height: u32,
-    ) -> String;
+    ) -> Result<String>;
 }
 
 /**

--- a/src/scatter.rs
+++ b/src/scatter.rs
@@ -3,10 +3,10 @@ use std::f64;
 use svg;
 
 use axis;
-use svg_render;
-use text_render;
 use representation::ContinuousRepresentation;
 use style;
+use svg_render;
+use text_render;
 
 /// `Style` follows the 'optional builder' pattern
 /// Each field is a `Option` which start as `None`

--- a/src/scatter.rs
+++ b/src/scatter.rs
@@ -3,6 +3,7 @@ use std::f64;
 use svg;
 
 use axis;
+use errors::Result;
 use representation::ContinuousRepresentation;
 use style;
 use svg_render;
@@ -92,10 +93,8 @@ pub struct Scatter {
 
 impl Scatter {
     pub fn from_slice(v: &[(f64, f64)]) -> Self {
-        let mut data: Vec<(f64, f64)> = vec![];
-        for &(x, y) in v {
-            data.push((x, y));
-        }
+        let mut data = Vec::new();
+        data.extend_from_slice(v);
 
         Scatter {
             data: data,
@@ -112,29 +111,29 @@ impl Scatter {
         &self.style
     }
 
-    fn x_range(&self) -> (f64, f64) {
+    fn x_range(&self) -> Result<(f64, f64)> {
         let mut min = f64::INFINITY;
         let mut max = f64::NEG_INFINITY;
         for &(x, _) in &self.data {
             min = min.min(x);
             max = max.max(x);
         }
-        (min, max)
+        Ok((min, max))
     }
 
-    fn y_range(&self) -> (f64, f64) {
+    fn y_range(&self) -> Result<(f64, f64)> {
         let mut min = f64::INFINITY;
         let mut max = f64::NEG_INFINITY;
         for &(_, y) in &self.data {
             min = min.min(y);
             max = max.max(y);
         }
-        (min, max)
+        Ok((min, max))
     }
 }
 
 impl ContinuousRepresentation for Scatter {
-    fn range(&self, dim: u32) -> (f64, f64) {
+    fn range(&self, dim: u32) -> Result<(f64, f64)> {
         match dim {
             0 => self.x_range(),
             1 => self.y_range(),

--- a/src/scatter.rs
+++ b/src/scatter.rs
@@ -147,15 +147,15 @@ impl ContinuousRepresentation for Scatter {
         y_axis: &axis::ContinuousAxis,
         face_width: f64,
         face_height: f64,
-    ) -> svg::node::element::Group {
-        svg_render::draw_face_points(
+    ) -> Result<svg::node::element::Group> {
+        Ok(svg_render::draw_face_points(
             &self.data,
             x_axis,
             y_axis,
             face_width,
             face_height,
             &self.style,
-        )
+        ))
     }
 
     fn to_text(
@@ -164,14 +164,14 @@ impl ContinuousRepresentation for Scatter {
         y_axis: &axis::ContinuousAxis,
         face_width: u32,
         face_height: u32,
-    ) -> String {
-        text_render::render_face_points(
+    ) -> Result<String> {
+        Ok(text_render::render_face_points(
             &self.data,
             x_axis,
             y_axis,
             face_width,
             face_height,
             &self.style,
-        )
+        ))
     }
 }

--- a/src/svg_render.rs
+++ b/src/svg_render.rs
@@ -1,10 +1,10 @@
 use std;
 
-use svg::Node;
 use svg::node;
+use svg::Node;
 
-use histogram;
 use axis;
+use histogram;
 use style;
 use utils;
 use utils::PairWise;

--- a/src/svg_render.rs
+++ b/src/svg_render.rs
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn test_value_to_face_offset() {
-        let axis = axis::ContinuousAxis::new(-2., 5.);
+        let axis = axis::ContinuousAxis::new(-2., 5.).unwrap();
         assert_eq!(value_to_face_offset(-2.0, &axis, 14.0), 0.0);
         assert_eq!(value_to_face_offset(5.0, &axis, 14.0), 14.0);
         assert_eq!(value_to_face_offset(0.0, &axis, 14.0), 4.0);

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -1,13 +1,12 @@
 //! A module for plotting graphs
 
-use std::collections::HashMap;
 use std;
+use std::collections::HashMap;
 
-use histogram;
-use scatter;
 use axis;
-use utils::PairWise;
+use histogram;
 use style;
+use utils::PairWise;
 
 // Given a value like a tick label or a bin count,
 // calculate how far from the x-axis it should be plotted
@@ -478,6 +477,7 @@ pub fn overlay(under: &str, over: &str, x: i32, y: i32) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::super::scatter;
     use super::*;
 
     #[test]

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -534,7 +534,7 @@ mod tests {
     #[test]
     fn test_value_to_axis_cell_offset() {
         assert_eq!(
-            value_to_axis_cell_offset(3.0, &axis::ContinuousAxis::new(5.0, 10.0), 10),
+            value_to_axis_cell_offset(3.0, &axis::ContinuousAxis::new(5.0, 10.0).unwrap(), 10),
             -4
         );
     }
@@ -576,7 +576,7 @@ mod tests {
 
     #[test]
     fn test_render_y_axis_strings() {
-        let y_axis = axis::ContinuousAxis::new(0.0, 10.0);
+        let y_axis = axis::ContinuousAxis::new(0.0, 10.0).unwrap();
 
         let (y_axis_string, longest_y_label_width) = render_y_axis_strings(&y_axis, 10);
 
@@ -588,7 +588,7 @@ mod tests {
 
     #[test]
     fn test_render_x_axis_strings() {
-        let x_axis = axis::ContinuousAxis::new(0.0, 10.0);
+        let x_axis = axis::ContinuousAxis::new(0.0, 10.0).unwrap();
 
         let (x_axis_string, start_offset) = render_x_axis_strings(&x_axis, 20);
 
@@ -602,9 +602,9 @@ mod tests {
     #[test]
     fn test_render_face_bars() {
         let data = vec![0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
-        let h = histogram::Histogram::from_slice(&data, 10);
-        let x_axis = axis::ContinuousAxis::new(0.3, 7.5);
-        let y_axis = axis::ContinuousAxis::new(0., 3.);
+        let h = histogram::Histogram::from_slice(&data, 10).unwrap();
+        let x_axis = axis::ContinuousAxis::new(0.3, 7.5).unwrap();
+        let y_axis = axis::ContinuousAxis::new(0., 3.).unwrap();
         let strings = render_face_bars(&h, &x_axis, &y_axis, 20, 10);
         assert_eq!(strings.lines().count(), 10);
         assert!(strings.lines().all(|s| s.chars().count() == 20));
@@ -636,8 +636,8 @@ mod tests {
             (8.5, 3.7),
         ];
         let s = scatter::Scatter::from_slice(&data);
-        let x_axis = axis::ContinuousAxis::new(-3.575, 9.075);
-        let y_axis = axis::ContinuousAxis::new(-1.735, 5.635);
+        let x_axis = axis::ContinuousAxis::new(-3.575, 9.075).unwrap();
+        let y_axis = axis::ContinuousAxis::new(-1.735, 5.635).unwrap();
         let style = scatter::Style::new();
         let strings = render_face_points(&s.data, &x_axis, &y_axis, 20, 10, &style);
         assert_eq!(strings.lines().count(), 10);

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -1,5 +1,7 @@
 //! A module for plotting graphs
 
+use failure::ResultExt;
+
 use std;
 use std::collections::HashMap;
 
@@ -285,7 +287,8 @@ pub fn render_face_bars(
 ) -> Result<String> {
     let bound_cells = bound_cell_offsets(h, x_axis, face_width);
 
-    let cell_bins = bins_for_cells(&bound_cells, face_width)?;
+    let cell_bins = bins_for_cells(&bound_cells, face_width)
+        .context("calculating bins for cells")?;
 
     // counts per bin converted to rows per column
     let cell_heights: Vec<_> = cell_bins

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
+use std::f64;
 use std::iter::{Skip, Zip};
 use std::slice::Iter;
-use std::f64;
 
 pub trait PairWise<T> {
     fn pairwise(&self) -> Zip<Iter<T>, Skip<Iter<T>>>;

--- a/src/view.rs
+++ b/src/view.rs
@@ -151,7 +151,7 @@ impl<'a> View for ContinuousView<'a> {
 
         // Then, based on those ranges, draw each repr as an SVG
         for repr in &self.representations {
-            let repr_group = repr.to_svg(&x_axis, &y_axis, face_width, face_height);
+            let repr_group = repr.to_svg(&x_axis, &y_axis, face_width, face_height)?;
             view_group.append(repr_group);
         }
 
@@ -186,7 +186,7 @@ impl<'a> View for ContinuousView<'a> {
         let mut view_string = blank.join("\n");
 
         for repr in &self.representations {
-            let face_string = repr.to_text(&x_axis, &y_axis, face_width, face_height);
+            let face_string = repr.to_text(&x_axis, &y_axis, face_width, face_height)?;
             view_string =
                 text_render::overlay(&view_string, &face_string, left_gutter_width as i32 + 1, 0);
         }

--- a/src/view.rs
+++ b/src/view.rs
@@ -12,8 +12,8 @@ use std::f64;
 use svg;
 use svg::Node;
 
-use representation::{DiscreteRepresentation, ContinuousRepresentation};
 use axis;
+use representation::{ContinuousRepresentation, DiscreteRepresentation};
 use svg_render;
 use text_render;
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -151,7 +151,8 @@ impl<'a> View for ContinuousView<'a> {
 
         // Then, based on those ranges, draw each repr as an SVG
         for repr in &self.representations {
-            let repr_group = repr.to_svg(&x_axis, &y_axis, face_width, face_height)?;
+            let repr_group = repr.to_svg(&x_axis, &y_axis, face_width, face_height)
+                .context("converting representation to svg")?;
             view_group.append(repr_group);
         }
 
@@ -186,7 +187,8 @@ impl<'a> View for ContinuousView<'a> {
         let mut view_string = blank.join("\n");
 
         for repr in &self.representations {
-            let face_string = repr.to_text(&x_axis, &y_axis, face_width, face_height)?;
+            let face_string = repr.to_text(&x_axis, &y_axis, face_width, face_height)
+                .context("converting representation to text")?;
             view_string =
                 text_render::overlay(&view_string, &face_string, left_gutter_width as i32 + 1, 0);
         }


### PR DESCRIPTION
Start to implement error handling throughout.

Motivated by #7, we add error handling through the `failure` crate, adding context where possible.

This is WIP so not ready to merge yet. We need to ideally remove every:

- bare `unwrap`
- `assert!`

from the codebase.