### PR TITLE
Ranges fail without hardcoded values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 - Add ability to set dimensions of plot (PR #8)
 
 ### Changed
+- Change `create_axes`, `save`, `to_svg` and `to_text` to return `Result` indicating an error.
 - Make `representation` module public.
 - Rename `Scatter::from_vec` to `Scatter::from_slice`.
 - Rename `Histogram::from_vec` to `Histogram::from_slice`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ travis-ci = { repository = "milliams/plotlib" }
 
 [dependencies]
 svg = "0.5.11"
+failure = "0.1.1"

--- a/examples/boxplot_svg.rs
+++ b/examples/boxplot_svg.rs
@@ -13,5 +13,5 @@ fn main() {
         .add(&b2)
         .x_label("Experiment")
         .y_label("y");
-    plotlib::page::Page::single(&v).dimensions(400, 300).save("boxplot.svg");
+    plotlib::page::Page::single(&v).dimensions(400, 300).save("boxplot.svg").expect("saving svg");
 }

--- a/examples/boxplot_svg.rs
+++ b/examples/boxplot_svg.rs
@@ -13,5 +13,8 @@ fn main() {
         .add(&b2)
         .x_label("Experiment")
         .y_label("y");
-    plotlib::page::Page::single(&v).dimensions(400, 300).save("boxplot.svg").expect("saving svg");
+    plotlib::page::Page::single(&v)
+        .dimensions(400, 300)
+        .save("boxplot.svg")
+        .expect("saving svg");
 }

--- a/examples/function_svg.rs
+++ b/examples/function_svg.rs
@@ -16,5 +16,7 @@ fn main() {
         .add(&f1)
         .add(&f2)
         .add(&f3);
-    plotlib::page::Page::single(&v).save("function.svg").expect("saving svg");
+    plotlib::page::Page::single(&v)
+        .save("function.svg")
+        .expect("saving svg");
 }

--- a/examples/function_svg.rs
+++ b/examples/function_svg.rs
@@ -16,5 +16,5 @@ fn main() {
         .add(&f1)
         .add(&f2)
         .add(&f3);
-    plotlib::page::Page::single(&v).save("function.svg");
+    plotlib::page::Page::single(&v).save("function.svg").expect("saving svg");
 }

--- a/examples/histogram_svg.rs
+++ b/examples/histogram_svg.rs
@@ -7,5 +7,5 @@ fn main() {
     let h = plotlib::histogram::Histogram::from_slice(&data, 10)
         .style(plotlib::histogram::Style::new().fill("burlywood"));
     let v = plotlib::view::ContinuousView::new().add(&h);
-    plotlib::page::Page::single(&v).save("histogram.svg");
+    plotlib::page::Page::single(&v).save("histogram.svg").expect("saving svg");
 }

--- a/examples/histogram_svg.rs
+++ b/examples/histogram_svg.rs
@@ -7,5 +7,7 @@ fn main() {
     let h = plotlib::histogram::Histogram::from_slice(&data, 10)
         .style(plotlib::histogram::Style::new().fill("burlywood"));
     let v = plotlib::view::ContinuousView::new().add(&h);
-    plotlib::page::Page::single(&v).save("histogram.svg").expect("saving svg");
+    plotlib::page::Page::single(&v)
+        .save("histogram.svg")
+        .expect("saving svg");
 }

--- a/examples/histogram_text.rs
+++ b/examples/histogram_text.rs
@@ -4,5 +4,5 @@ fn main() {
     let data = [0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
     let h = plotlib::histogram::Histogram::from_slice(&data, 10);
     let v = plotlib::view::ContinuousView::new().add(&h);
-    println!("{}", plotlib::page::Page::single(&v).to_text());
+    println!("{}", plotlib::page::Page::single(&v).to_text().unwrap());
 }

--- a/examples/line_svg.rs
+++ b/examples/line_svg.rs
@@ -6,5 +6,7 @@ fn main() {
     let l1 = plotlib::line::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
         .style(plotlib::line::Style::new().colour("burlywood"));
     let v = plotlib::view::ContinuousView::new().add(&l1);
-    plotlib::page::Page::single(&v).save("line.svg").expect("saving svg");
+    plotlib::page::Page::single(&v)
+        .save("line.svg")
+        .expect("saving svg");
 }

--- a/examples/line_svg.rs
+++ b/examples/line_svg.rs
@@ -6,5 +6,5 @@ fn main() {
     let l1 = plotlib::line::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
         .style(plotlib::line::Style::new().colour("burlywood"));
     let v = plotlib::view::ContinuousView::new().add(&l1);
-    plotlib::page::Page::single(&v).save("line.svg");
+    plotlib::page::Page::single(&v).save("line.svg").expect("saving svg");
 }

--- a/examples/scatter_svg.rs
+++ b/examples/scatter_svg.rs
@@ -26,7 +26,9 @@ fn main() {
         .y_range(-2., 6.)
         .x_label("Some varying variable")
         .y_label("The response of something");
-    plotlib::page::Page::single(&v).save("scatter.svg").expect("saving svg");
+    plotlib::page::Page::single(&v)
+        .save("scatter.svg")
+        .expect("saving svg");
 
     /*
     //

--- a/examples/scatter_svg.rs
+++ b/examples/scatter_svg.rs
@@ -26,7 +26,7 @@ fn main() {
         .y_range(-2., 6.)
         .x_label("Some varying variable")
         .y_label("The response of something");
-    plotlib::page::Page::single(&v).save("scatter.svg");
+    plotlib::page::Page::single(&v).save("scatter.svg").expect("saving svg");
 
     /*
     //

--- a/examples/scatter_text.rs
+++ b/examples/scatter_text.rs
@@ -21,5 +21,5 @@ fn main() {
         .y_range(-2., 6.)
         .x_label("Some varying variable")
         .y_label("The response of something");
-    println!("{}", plotlib::page::Page::single(&v).to_text());
+    println!("{}", plotlib::page::Page::single(&v).to_text().unwrap());
 }

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -17,6 +17,10 @@ impl Range {
             upper: upper,
         }
     }
+
+    pub(crate) fn is_valid(&self) -> bool {
+        self.lower < self.upper
+    }
 }
 
 #[derive(Debug)]

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -273,11 +273,15 @@ mod tests {
     #[test]
     fn test_calculate_ticks() {
         macro_rules! assert_approx_eq {
-            ($a:expr, $b:expr) => ({
+            ($a:expr, $b:expr) => {{
                 let (a, b) = (&$a, &$b);
-                assert!((*a - *b).abs() < 1.0e-6,
-                        "{} is not approximately equal to {}", *a, *b);
-            })
+                assert!(
+                    (*a - *b).abs() < 1.0e-6,
+                    "{} is not approximately equal to {}",
+                    *a,
+                    *b
+                );
+            }};
         }
 
         for (prod, want) in calculate_ticks(0.0, 1.0, 6)

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -12,7 +12,6 @@ pub struct Range {
 
 impl Range {
     pub fn new(lower: f64, upper: f64) -> Range {
-        assert!(lower < upper);
         Range {
             lower: lower,
             upper: upper,

--- a/src/boxplot.rs
+++ b/src/boxplot.rs
@@ -19,8 +19,8 @@ use svg;
 
 use axis;
 use representation::DiscreteRepresentation;
-use svg_render;
 use style;
+use svg_render;
 use utils;
 
 #[derive(Debug, Default)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,3 @@
+use failure;
+
+pub type Result<T> = ::std::result::Result<T, failure::Error>;

--- a/src/function.rs
+++ b/src/function.rs
@@ -19,8 +19,8 @@ use svg;
 
 use axis;
 use representation::ContinuousRepresentation;
-use svg_render;
 use style;
+use svg_render;
 
 #[derive(Debug, Default)]
 pub struct Style {

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -23,11 +23,11 @@ TODO:
 use svg;
 
 use axis;
-use utils::PairWise;
-use svg_render;
-use text_render;
 use representation::ContinuousRepresentation;
 use style;
+use svg_render;
+use text_render;
+use utils::PairWise;
 
 #[derive(Debug, Default)]
 pub struct Style {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ in this case, interpreting the bins and colours to create SVG elements.
 */
 
 extern crate svg;
+#[macro_use]
+extern crate failure;
 
 pub mod representation;
 pub mod view;
@@ -91,3 +93,4 @@ mod axis;
 mod utils;
 mod text_render;
 mod svg_render;
+mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,18 +79,18 @@ extern crate svg;
 #[macro_use]
 extern crate failure;
 
+pub mod page;
 pub mod representation;
 pub mod view;
-pub mod page;
 
-pub mod histogram;
-pub mod scatter;
-pub mod function;
-pub mod line;
-pub mod style;
-pub mod boxplot;
 mod axis;
-mod utils;
-mod text_render;
-mod svg_render;
+pub mod boxplot;
 mod errors;
+pub mod function;
+pub mod histogram;
+pub mod line;
+pub mod scatter;
+pub mod style;
+mod svg_render;
+mod text_render;
+mod utils;

--- a/src/line.rs
+++ b/src/line.rs
@@ -19,8 +19,8 @@ use svg;
 
 use axis;
 use representation::ContinuousRepresentation;
-use svg_render;
 use style;
+use svg_render;
 
 #[derive(Debug, Default)]
 pub struct Style {

--- a/src/page.rs
+++ b/src/page.rs
@@ -51,7 +51,7 @@ impl<'a> Page<'a> {
     /**
     Render the plot to an svg document
     */
-    pub fn to_svg(&self) -> svg::Document {
+    pub fn to_svg(&self) -> Result<svg::Document> {
         let (width, height) = self.dimensions;
         let mut document = Document::new().set("viewBox", (0, 0, width, height));
 
@@ -62,17 +62,17 @@ impl<'a> Page<'a> {
 
         // TODO put multiple views in correct places
         for &view in &self.views {
-            let view_group = view.to_svg((width-x_margin) as f64, (height-y_margin) as f64)
+            let view_group = view.to_svg((width-x_margin) as f64, (height-y_margin) as f64)?
                 .set("transform", format!("translate({}, {})", x_offset, height as f64-y_offset));
             document.append(view_group);
         }
-        document
+        Ok(document)
     }
 
     /**
     Render the plot to an `String`
     */
-    pub fn to_text(&self) -> String {
+    pub fn to_text(&self) -> Result<String> {
         // TODO compose multiple views into a plot
         let view = self.views[0];
         view.to_text(90, 30)
@@ -90,7 +90,7 @@ impl<'a> Page<'a> {
     {
         match path.as_ref().extension().and_then(OsStr::to_str) {
             Some("svg") => {
-                svg::save(path, &self.to_svg())
+                svg::save(path, &self.to_svg()?)
                     .context("saving svg")
                     .map_err(From::from)
             }

--- a/src/page.rs
+++ b/src/page.rs
@@ -2,12 +2,12 @@
 The `page` module provides structures for laying out and rendering multiple views.
 */
 
-use std::path::Path;
 use std::ffi::OsStr;
+use std::path::Path;
 
 use svg;
-use svg::Node;
 use svg::Document;
+use svg::Node;
 
 use errors::Result;
 use view::View;
@@ -20,7 +20,7 @@ A single page page laying out the views in a grid
 pub struct Page<'a> {
     views: Vec<&'a View>,
     num_views: u32,
-    dimensions: (u32, u32)
+    dimensions: (u32, u32),
 }
 
 impl<'a> Page<'a> {
@@ -31,13 +31,13 @@ impl<'a> Page<'a> {
         Page {
             views: vec![view],
             num_views: 1,
-            dimensions: (600, 400)
+            dimensions: (600, 400),
         }
     }
 
     /// Set the dimensions of the plot.
     pub fn dimensions(mut self, x: u32, y: u32) -> Self {
-        self.dimensions = (x,y);
+        self.dimensions = (x, y);
         self
     }
 
@@ -57,13 +57,16 @@ impl<'a> Page<'a> {
 
         let x_margin = 80;
         let y_margin = 60;
-        let x_offset = 0.6*x_margin as f64;
-        let y_offset = 0.6*y_margin as f64;
+        let x_offset = 0.6 * x_margin as f64;
+        let y_offset = 0.6 * y_margin as f64;
 
         // TODO put multiple views in correct places
         for &view in &self.views {
-            let view_group = view.to_svg((width-x_margin) as f64, (height-y_margin) as f64)?
-                .set("transform", format!("translate({}, {})", x_offset, height as f64-y_offset));
+            let view_group = view.to_svg((width - x_margin) as f64, (height - y_margin) as f64)?
+                .set(
+                    "transform",
+                    format!("translate({}, {})", x_offset, height as f64 - y_offset),
+                );
             document.append(view_group);
         }
         Ok(document)
@@ -89,14 +92,10 @@ impl<'a> Page<'a> {
         P: AsRef<Path>,
     {
         match path.as_ref().extension().and_then(OsStr::to_str) {
-            Some("svg") => {
-                svg::save(path, &self.to_svg()?)
-                    .context("saving svg")
-                    .map_err(From::from)
-            }
-            _ => {
-                Ok(())
-            }
+            Some("svg") => svg::save(path, &self.to_svg()?)
+                .context("saving svg")
+                .map_err(From::from),
+            _ => Ok(()),
         }
     }
 }

--- a/src/page.rs
+++ b/src/page.rs
@@ -9,7 +9,10 @@ use svg;
 use svg::Node;
 use svg::Document;
 
+use errors::Result;
 use view::View;
+
+use failure::ResultExt;
 
 /**
 A single page page laying out the views in a grid
@@ -81,16 +84,18 @@ impl<'a> Page<'a> {
     The type of file will be based on the file extension.
     */
 
-    pub fn save<P>(&self, path: P)
+    pub fn save<P>(&self, path: P) -> Result<()>
     where
         P: AsRef<Path>,
     {
         match path.as_ref().extension().and_then(OsStr::to_str) {
             Some("svg") => {
-                svg::save(path, &self.to_svg()).unwrap();
+                svg::save(path, &self.to_svg())
+                    .context("saving svg")
+                    .map_err(From::from)
             }
             _ => {
-                // some default
+                Ok(())
             }
         }
     }

--- a/src/representation.rs
+++ b/src/representation.rs
@@ -12,8 +12,8 @@ These points may then be layered with other SVG elements from other representati
 `view::View`.
 */
 
-use svg;
 use axis;
+use svg;
 
 /**
 A representation of data that is continuous in two dimensions.

--- a/src/scatter.rs
+++ b/src/scatter.rs
@@ -3,10 +3,10 @@ use std::f64;
 use svg;
 
 use axis;
-use svg_render;
-use text_render;
 use representation::ContinuousRepresentation;
 use style;
+use svg_render;
+use text_render;
 
 /// `Style` follows the 'optional builder' pattern
 /// Each field is a `Option` which start as `None`

--- a/src/svg_render.rs
+++ b/src/svg_render.rs
@@ -1,10 +1,10 @@
 use std;
 
-use svg::Node;
 use svg::node;
+use svg::Node;
 
-use histogram;
 use axis;
+use histogram;
 use style;
 use utils;
 use utils::PairWise;

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -1,13 +1,13 @@
 //! A module for plotting graphs
 
-use std::collections::HashMap;
 use std;
+use std::collections::HashMap;
 
+use axis;
 use histogram;
 use scatter;
-use axis;
-use utils::PairWise;
 use style;
+use utils::PairWise;
 
 // Given a value like a tick label or a bin count,
 // calculate how far from the x-axis it should be plotted

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
+use std::f64;
 use std::iter::{Skip, Zip};
 use std::slice::Iter;
-use std::f64;
 
 pub trait PairWise<T> {
     fn pairwise(&self) -> Zip<Iter<T>, Skip<Iter<T>>>;

--- a/src/view.rs
+++ b/src/view.rs
@@ -12,11 +12,11 @@ use std::f64;
 use svg;
 use svg::Node;
 
-use representation::{DiscreteRepresentation, ContinuousRepresentation};
 use axis;
+use errors::Result;
+use representation::{ContinuousRepresentation, DiscreteRepresentation};
 use svg_render;
 use text_render;
-use errors::Result;
 
 pub trait View {
     fn to_svg(&self, face_width: f64, face_height: f64) -> Result<svg::node::element::Group>;
@@ -119,13 +119,21 @@ impl<'a> ContinuousView<'a> {
         let default_x_range = self.default_x_range();
         let x_range = self.x_range.as_ref().unwrap_or(&default_x_range);
         if !x_range.is_valid() {
-            return Err(format_err!("Invalid x_range: {} >= {}. Please specify the x_range manually.", x_range.lower, x_range.upper));
+            return Err(format_err!(
+                "Invalid x_range: {} >= {}. Please specify the x_range manually.",
+                x_range.lower,
+                x_range.upper
+            ));
         }
 
         let default_y_range = self.default_y_range();
         let y_range = self.y_range.as_ref().unwrap_or(&default_y_range);
         if !y_range.is_valid() {
-            return Err(format_err!("Invalid y_range: {} >= {}. Please specify the y_range manually.", y_range.lower, y_range.upper));
+            return Err(format_err!(
+                "Invalid y_range: {} >= {}. Please specify the y_range manually.",
+                y_range.lower,
+                y_range.upper
+            ));
         }
 
         let x_label: String = self.x_label.clone().unwrap_or_else(|| "".to_string());
@@ -254,7 +262,6 @@ impl<'a> DiscreteView<'a> {
         self
     }
 
-
     /**
     Set the label for the x-axis
     */
@@ -265,7 +272,6 @@ impl<'a> DiscreteView<'a> {
         self.x_label = Some(value.into());
         self
     }
-
 
     /**
     Set the label for the y-axis

--- a/src/view.rs
+++ b/src/view.rs
@@ -19,8 +19,8 @@ use text_render;
 use errors::Result;
 
 pub trait View {
-    fn to_svg(&self, face_width: f64, face_height: f64) -> svg::node::element::Group;
-    fn to_text(&self, face_width: u32, face_height: u32) -> String;
+    fn to_svg(&self, face_width: f64, face_height: f64) -> Result<svg::node::element::Group>;
+    fn to_text(&self, face_width: u32, face_height: u32) -> Result<String>;
 }
 
 /// Standard 1-dimensional view with a continuous x-axis
@@ -145,10 +145,10 @@ impl<'a> View for ContinuousView<'a> {
     /**
     Create an SVG rendering of the view
     */
-    fn to_svg(&self, face_width: f64, face_height: f64) -> svg::node::element::Group {
+    fn to_svg(&self, face_width: f64, face_height: f64) -> Result<svg::node::element::Group> {
         let mut view_group = svg::node::element::Group::new();
 
-        let (x_axis, y_axis) = self.create_axes().expect("invalid axes");
+        let (x_axis, y_axis) = self.create_axes()?;
 
         // Then, based on those ranges, draw each repr as an SVG
         for repr in &self.representations {
@@ -159,14 +159,14 @@ impl<'a> View for ContinuousView<'a> {
         // Add in the axes
         view_group.append(svg_render::draw_x_axis(&x_axis, face_width));
         view_group.append(svg_render::draw_y_axis(&y_axis, face_height));
-        view_group
+        Ok(view_group)
     }
 
     /**
     Create a text rendering of the view
     */
-    fn to_text(&self, face_width: u32, face_height: u32) -> String {
-        let (x_axis, y_axis) = self.create_axes().expect("invalid axes");
+    fn to_text(&self, face_width: u32, face_height: u32) -> Result<String> {
+        let (x_axis, y_axis) = self.create_axes()?;
 
         let (y_axis_string, longest_y_label_width) =
             text_render::render_y_axis_strings(&y_axis, face_height);
@@ -205,7 +205,7 @@ impl<'a> View for ContinuousView<'a> {
             face_height as i32,
         );
 
-        view_string
+        Ok(view_string)
     }
 }
 
@@ -305,12 +305,16 @@ impl<'a> DiscreteView<'a> {
         axis::Range::new(y_min - range / 10., y_max + range / 10.)
     }
 
-    fn create_axes(&self) -> (axis::DiscreteAxis, axis::ContinuousAxis) {
+    fn create_axes(&self) -> Result<(axis::DiscreteAxis, axis::ContinuousAxis)> {
         let default_x_ticks = self.default_x_ticks();
         let x_range = self.x_range.as_ref().unwrap_or(&default_x_ticks);
 
         let default_y_range = self.default_y_range();
         let y_range = self.y_range.as_ref().unwrap_or(&default_y_range);
+
+        if !y_range.is_valid() {
+            return Err(format_err!("invalid y_range: {:?}", y_range));
+        }
 
         let default_x_label = "".to_string();
         let x_label: String = self.x_label.clone().unwrap_or(default_x_label);
@@ -321,15 +325,15 @@ impl<'a> DiscreteView<'a> {
         let x_axis = axis::DiscreteAxis::new(x_range).label(x_label);
         let y_axis = axis::ContinuousAxis::new(y_range.lower, y_range.upper).label(y_label);
 
-        (x_axis, y_axis)
+        Ok((x_axis, y_axis))
     }
 }
 
 impl<'a> View for DiscreteView<'a> {
-    fn to_svg(&self, face_width: f64, face_height: f64) -> svg::node::element::Group {
+    fn to_svg(&self, face_width: f64, face_height: f64) -> Result<svg::node::element::Group> {
         let mut view_group = svg::node::element::Group::new();
 
-        let (x_axis, y_axis) = self.create_axes();
+        let (x_axis, y_axis) = self.create_axes()?;
 
         // Then, based on those ranges, draw each repr as an SVG
         for repr in &self.representations {
@@ -340,11 +344,11 @@ impl<'a> View for DiscreteView<'a> {
         // Add in the axes
         view_group.append(svg_render::draw_discrete_x_axis(&x_axis, face_width));
         view_group.append(svg_render::draw_y_axis(&y_axis, face_height));
-        view_group
+        Ok(view_group)
     }
 
-    fn to_text(&self, face_width: u32, face_height: u32) -> String {
-        "".into()
+    fn to_text(&self, face_width: u32, face_height: u32) -> Result<String> {
+        Ok("".into())
     }
 }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -128,11 +128,8 @@ impl<'a> ContinuousView<'a> {
             return Err(format_err!("Invalid y_range: {} >= {}. Please specify the y_range manually.", y_range.lower, y_range.upper));
         }
 
-        let default_x_label = "".to_string();
-        let x_label: String = self.x_label.clone().unwrap_or(default_x_label);
-
-        let default_y_label = "".to_string();
-        let y_label: String = self.y_label.clone().unwrap_or(default_y_label);
+        let x_label: String = self.x_label.clone().unwrap_or_else(|| "".to_string());
+        let y_label: String = self.y_label.clone().unwrap_or_else(|| "".to_string());
 
         let x_axis = axis::ContinuousAxis::new(x_range.lower, x_range.upper).label(x_label);
         let y_axis = axis::ContinuousAxis::new(y_range.lower, y_range.upper).label(y_label);

--- a/src/view.rs
+++ b/src/view.rs
@@ -119,13 +119,13 @@ impl<'a> ContinuousView<'a> {
         let default_x_range = self.default_x_range();
         let x_range = self.x_range.as_ref().unwrap_or(&default_x_range);
         if !x_range.is_valid() {
-            return Err(format_err!("invalid x_range: {:?}", x_range));
+            return Err(format_err!("Invalid x_range: {} >= {}. Please specify the x_range manually.", x_range.lower, x_range.upper));
         }
 
         let default_y_range = self.default_y_range();
         let y_range = self.y_range.as_ref().unwrap_or(&default_y_range);
         if !y_range.is_valid() {
-            return Err(format_err!("invalid y_range: {:?}", y_range));
+            return Err(format_err!("Invalid y_range: {} >= {}. Please specify the y_range manually.", y_range.lower, y_range.upper));
         }
 
         let default_x_label = "".to_string();

--- a/tests/test_no_data.rs
+++ b/tests/test_no_data.rs
@@ -28,7 +28,8 @@ fn test_data_with_one_length() {
 
     // A page with a single view is then saved to an SVG file
     Page::single(&v)
-        .save("/tmp/scatter_one_length.svg").unwrap();
+        .save("/tmp/scatter_one_length.svg")
+        .unwrap();
 }
 
 #[test]
@@ -53,7 +54,8 @@ fn test_data_with_no_length() {
 
     // A page with a single view is then saved to an SVG file
     Page::single(&v)
-        .save("/tmp/scatter_zero_length.svg").unwrap();
+        .save("/tmp/scatter_zero_length.svg")
+        .unwrap();
 }
 
 #[test]
@@ -77,5 +79,6 @@ fn test_data_with_one_length_and_autoscaling_axes_limits() {
 
     // // A page with a single view is then saved to an SVG file
     Page::single(&v)
-        .save("/tmp/scatter_one_length.svg").unwrap();
+        .save("/tmp/scatter_one_length.svg")
+        .unwrap();
 }

--- a/tests/test_no_data.rs
+++ b/tests/test_no_data.rs
@@ -57,7 +57,7 @@ fn test_data_with_no_length() {
 }
 
 #[test]
-#[should_panic(expected = "invalid x_range")]
+#[should_panic(expected = "Invalid x_range")]
 fn test_data_with_one_length_and_autoscaling_axes_limits() {
     // Scatter plots expect a list of pairs
     let data1 = [(-3.0, 2.3)];

--- a/tests/test_no_data.rs
+++ b/tests/test_no_data.rs
@@ -30,3 +30,28 @@ fn test_data_with_one_length() {
     Page::single(&v)
         .save("/tmp/scatter_one_length.svg");
 }
+
+#[test]
+fn test_data_with_no_length() {
+    // Scatter plots expect a list of pairs
+    let data1 = [];
+
+    // We create our scatter plot from the data
+    let s1 = Scatter::from_slice(&data1).style(
+        scatter::Style::new()
+            .marker(Marker::Square) // setting the marker to be a square
+            .colour("#DD3355"),
+    ); // and a custom colour
+
+    // The 'view' describes what set of data is drawn
+    let v = ContinuousView::new()
+        .add(&s1)
+        .x_range(-5., 10.)
+        .y_range(-2., 6.)
+        .x_label("Some varying variable")
+        .y_label("The response of something");
+
+    // A page with a single view is then saved to an SVG file
+    Page::single(&v)
+        .save("/tmp/scatter_zero_length.svg");
+}

--- a/tests/test_no_data.rs
+++ b/tests/test_no_data.rs
@@ -1,0 +1,32 @@
+extern crate plotlib;
+
+use plotlib::page::Page;
+use plotlib::scatter;
+use plotlib::scatter::Scatter;
+use plotlib::style::{Marker, Point};
+use plotlib::view::ContinuousView;
+
+#[test]
+fn test_data_with_one_length() {
+    // Scatter plots expect a list of pairs
+    let data1 = [(-3.0, 2.3)];
+
+    // We create our scatter plot from the data
+    let s1 = Scatter::from_slice(&data1).style(
+        scatter::Style::new()
+            .marker(Marker::Square) // setting the marker to be a square
+            .colour("#DD3355"),
+    ); // and a custom colour
+
+    // The 'view' describes what set of data is drawn
+    let v = ContinuousView::new()
+        .add(&s1)
+        .x_range(-5., 10.)
+        .y_range(-2., 6.)
+        .x_label("Some varying variable")
+        .y_label("The response of something");
+
+    // A page with a single view is then saved to an SVG file
+    Page::single(&v)
+        .save("/tmp/scatter_one_length.svg");
+}

--- a/tests/test_no_data.rs
+++ b/tests/test_no_data.rs
@@ -57,7 +57,7 @@ fn test_data_with_no_length() {
 }
 
 #[test]
-#[should_panic(expected = "invalid axes")]
+#[should_panic(expected = "invalid x_range")]
 fn test_data_with_one_length_and_autoscaling_axes_limits() {
     // Scatter plots expect a list of pairs
     let data1 = [(-3.0, 2.3)];

--- a/tests/test_no_data.rs
+++ b/tests/test_no_data.rs
@@ -55,3 +55,27 @@ fn test_data_with_no_length() {
     Page::single(&v)
         .save("/tmp/scatter_zero_length.svg").unwrap();
 }
+
+#[test]
+#[should_panic(expected = "invalid axes")]
+fn test_data_with_one_length_and_autoscaling_axes_limits() {
+    // Scatter plots expect a list of pairs
+    let data1 = [(-3.0, 2.3)];
+
+    // We create our scatter plot from the data
+    let s1 = Scatter::from_slice(&data1).style(
+        scatter::Style::new()
+            .marker(Marker::Square) // setting the marker to be a square
+            .colour("#DD3355"),
+    ); // and a custom colour
+
+    // The 'view' describes what set of data is drawn
+    let v = ContinuousView::new()
+        .add(&s1)
+        .x_label("Some varying variable")
+        .y_label("The response of something");
+
+    // // A page with a single view is then saved to an SVG file
+    Page::single(&v)
+        .save("/tmp/scatter_one_length.svg").unwrap();
+}

--- a/tests/test_no_data.rs
+++ b/tests/test_no_data.rs
@@ -28,7 +28,7 @@ fn test_data_with_one_length() {
 
     // A page with a single view is then saved to an SVG file
     Page::single(&v)
-        .save("/tmp/scatter_one_length.svg");
+        .save("/tmp/scatter_one_length.svg").unwrap();
 }
 
 #[test]
@@ -53,5 +53,5 @@ fn test_data_with_no_length() {
 
     // A page with a single view is then saved to an SVG file
     Page::single(&v)
-        .save("/tmp/scatter_zero_length.svg");
+        .save("/tmp/scatter_zero_length.svg").unwrap();
 }


### PR DESCRIPTION
 When creating a new plot, the user can either specify the limits of each
axis, or let the code decide. This only works when there are more than
two data points (see #7).

This PR only affects the latter case. It means most functions while
plotting return `Result<T, failure::Error>` values, representing failure
to compute valid auto-ranges. If the chosen axis ranges are invalid
(i.e. `range.lower` >= `range.upper`) then an error type is returned.
The user can override this by choosing axis ranges.

This PR starts further development of adding the possibility of errors
and proper error handling. This implementation started with adding an
error type with invalid ranges, and propagating the error types until
the compiler stopped complaining.

Additionally, three tests have been added under `tests/test_no_data.rs`
which test:

1. specifying one data point but manually choosing the ranges works,
2. specifying zero data points but manually choosing the ranges works,
   and
3. specifying one data point but letting `plotlib` choose the axes
   limits does _not_ work, and in fact returns an `Err` type.

This PR supersedes #9 which was a much less targeted approach to adding
error handling.
