### PR TITLE
Fixing README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ fn main() {
     let data1 = [(-3.0, 2.3), (-1.6, 5.3), (0.3, 0.7), (4.3, -1.4), (6.4, 4.3), (8.5, 3.7)];
 
     // We create our scatter plot from the data
-    let s1 = Scatter::from_slice(&data1)
+    let s1 = Scatter::from_vec(&data1)
         .style(scatter::Style::new()
             .marker(Marker::Square) // setting the marker to be a square
             .colour("#DD3355")); // and a custom colour
 
     // We can plot multiple data sets in the same view
     let data2 = [(-1.4, 2.5), (7.2, -0.3)];
-    let s2 = Scatter::from_slice(&data2)
+    let s2 = Scatter::from_vec(&data2)
         .style(scatter::Style::new() // uses the default marker
             .colour("#35C788")); // and a different colour
 


### PR DESCRIPTION
The example code is using "from_slice" apparently from an older version.