### PR TITLE
Update for rust 2018 edition.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plotlib"
-version = "0.4.0"
+version = "0.3.0"
 authors = ["Matt Williams <matt@milliams.com>"]
 description = "Pure Rust plotting library"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "plotlib"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Matt Williams <matt@milliams.com>"]
 description = "Pure Rust plotting library"
 readme = "README.md"
 license = "MIT"
+edition = "2018"
 repository = "https://github.com/milliams/plotlib"
 categories = ["visualization", "science"]
 keywords = ["plotting", "plot", "graph", "chart", "histogram", "scatter"]

--- a/src/barchart.rs
+++ b/src/barchart.rs
@@ -17,10 +17,10 @@ use std::f64;
 
 use svg;
 
-use axis;
-use representation::CategoricalRepresentation;
-use style;
-use svg_render;
+use crate::axis;
+use crate::representation::CategoricalRepresentation;
+use crate::style;
+use crate::svg_render;
 
 #[derive(Debug, Default)]
 pub struct Style {

--- a/src/boxplot.rs
+++ b/src/boxplot.rs
@@ -17,11 +17,11 @@ use std::f64;
 
 use svg;
 
-use axis;
-use representation::CategoricalRepresentation;
-use style;
-use svg_render;
-use utils;
+use crate::axis;
+use crate::representation::CategoricalRepresentation;
+use crate::style;
+use crate::svg_render;
+use crate::utils;
 
 #[derive(Debug, Default)]
 pub struct Style {

--- a/src/function.rs
+++ b/src/function.rs
@@ -17,10 +17,10 @@ use std::f64;
 
 use svg;
 
-use axis;
-use representation::ContinuousRepresentation;
-use style;
-use svg_render;
+use crate::axis;
+use crate::representation::ContinuousRepresentation;
+use crate::style;
+use crate::svg_render;
 
 #[derive(Debug, Default)]
 pub struct Style {

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -24,12 +24,12 @@ use std;
 
 use svg;
 
-use axis;
-use representation::ContinuousRepresentation;
-use style;
-use svg_render;
-use text_render;
-use utils::PairWise;
+use crate::axis;
+use crate::representation::ContinuousRepresentation;
+use crate::style;
+use crate::svg_render;
+use crate::text_render;
+use crate::utils::PairWise;
 
 #[derive(Debug, Default)]
 pub struct Style {

--- a/src/line.rs
+++ b/src/line.rs
@@ -17,10 +17,10 @@ use std::f64;
 
 use svg;
 
-use axis;
-use representation::ContinuousRepresentation;
-use style;
-use svg_render;
+use crate::axis;
+use crate::representation::ContinuousRepresentation;
+use crate::style;
+use crate::svg_render;
 
 #[derive(Debug, Default)]
 pub struct Style {

--- a/src/page.rs
+++ b/src/page.rs
@@ -9,8 +9,8 @@ use svg;
 use svg::Document;
 use svg::Node;
 
-use errors::Result;
-use view::View;
+use crate::errors::Result;
+use crate::view::View;
 
 use failure::ResultExt;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,7 +1,7 @@
-use scatter;
-use histogram;
-use text_render;
-use svg_render;
+use crate::scatter;
+use crate::histogram;
+use crate::text_render;
+use crate::svg_render;
 
 pub trait Render {
     fn to_svg(&self) -> svg_render::SVG;

--- a/src/representation.rs
+++ b/src/representation.rs
@@ -12,8 +12,8 @@ These points may then be layered with other SVG elements from other representati
 `view::View`.
 */
 
-use axis;
-use svg;
+use crate::axis;
+use crate::svg;
 
 /**
 A representation of data that is continuous in two dimensions.

--- a/src/scatter.rs
+++ b/src/scatter.rs
@@ -2,11 +2,11 @@ use std::f64;
 
 use svg;
 
-use axis;
-use representation::ContinuousRepresentation;
-use style;
-use svg_render;
-use text_render;
+use crate::axis;
+use crate::representation::ContinuousRepresentation;
+use crate::style;
+use crate::svg_render;
+use crate::text_render;
 
 /// `Style` follows the 'optional builder' pattern
 /// Each field is a `Option` which start as `None`

--- a/src/svg_render.rs
+++ b/src/svg_render.rs
@@ -3,11 +3,11 @@ use std;
 use svg::node;
 use svg::Node;
 
-use axis;
-use histogram;
-use style;
-use utils;
-use utils::PairWise;
+use crate::axis;
+use crate::histogram;
+use crate::style;
+use crate::utils;
+use crate::utils::PairWise;
 
 fn value_to_face_offset(value: f64, axis: &axis::ContinuousAxis, face_size: f64) -> f64 {
     let range = axis.max() - axis.min();

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -3,10 +3,10 @@
 use std;
 use std::collections::HashMap;
 
-use axis;
-use histogram;
-use style;
-use utils::PairWise;
+use crate::axis;
+use crate::histogram;
+use crate::style;
+use crate::utils::PairWise;
 
 // Given a value like a tick label or a bin count,
 // calculate how far from the x-axis it should be plotted
@@ -618,7 +618,7 @@ mod tests {
 
     #[test]
     fn test_render_face_points() {
-        use scatter;
+        use crate::scatter;
         let data = vec![
             (-3.0, 2.3),
             (-1.6, 5.3),

--- a/src/view.rs
+++ b/src/view.rs
@@ -12,11 +12,11 @@ use std::f64;
 use svg;
 use svg::Node;
 
-use axis;
-use errors::Result;
-use representation::{CategoricalRepresentation, ContinuousRepresentation};
-use svg_render;
-use text_render;
+use crate::axis;
+use crate::errors::Result;
+use crate::representation::{CategoricalRepresentation, ContinuousRepresentation};
+use crate::svg_render;
+use crate::text_render;
 
 pub trait View {
     fn to_svg(&self, face_width: f64, face_height: f64) -> Result<svg::node::element::Group>;


### PR DESCRIPTION
# Rationale
I ran some module issue when working on a project of my own, related to the changes made to module imports for rust 2018 (see link below). This change updates plotlib to work in rust 2018.

# Changes
- Update internal paths to use crate:: as required now.
- Update version number to v0.4.0.
- Set edition to 2018 in cargo.

To understand more about the rust 2018 changes see:
https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html