### PR TITLE
Remove extern crate lines from all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ The API is still very much in flux and is subject to change.
 For example, code like:
 
 ```rust
-extern crate plotlib;
 use plotlib::scatter::Scatter;
 use plotlib::scatter;
 use plotlib::style::{Marker, Point};

--- a/examples/barchart_svg.rs
+++ b/examples/barchart_svg.rs
@@ -1,5 +1,3 @@
-extern crate plotlib;
-
 use plotlib::style::BarChart;
 
 fn main() {

--- a/examples/boxplot_svg.rs
+++ b/examples/boxplot_svg.rs
@@ -1,5 +1,3 @@
-extern crate plotlib;
-
 use plotlib::style::BoxPlot;
 
 fn main() {

--- a/examples/function_svg.rs
+++ b/examples/function_svg.rs
@@ -1,5 +1,3 @@
-extern crate plotlib;
-
 use plotlib::style::Line;
 
 fn main() {

--- a/examples/histogram_svg.rs
+++ b/examples/histogram_svg.rs
@@ -1,5 +1,3 @@
-extern crate plotlib;
-
 use plotlib::style::Bar;
 
 fn main() {

--- a/examples/histogram_text.rs
+++ b/examples/histogram_text.rs
@@ -1,8 +1,12 @@
-extern crate plotlib;
-
 fn main() {
     let data = [0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
     let h = plotlib::histogram::Histogram::from_slice(&data, plotlib::histogram::Bins::Count(10));
     let v = plotlib::view::ContinuousView::new().add(&h);
-    println!("{}", plotlib::page::Page::single(&v).dimensions(60, 15).to_text().unwrap());
+    println!(
+        "{}",
+        plotlib::page::Page::single(&v)
+            .dimensions(60, 15)
+            .to_text()
+            .unwrap()
+    );
 }

--- a/examples/line_svg.rs
+++ b/examples/line_svg.rs
@@ -1,5 +1,3 @@
-extern crate plotlib;
-
 use plotlib::style::Line;
 
 fn main() {

--- a/examples/scatter_svg.rs
+++ b/examples/scatter_svg.rs
@@ -1,5 +1,3 @@
-extern crate plotlib;
-
 use plotlib::style::Point;
 
 fn main() {

--- a/examples/scatter_text.rs
+++ b/examples/scatter_text.rs
@@ -1,5 +1,3 @@
-extern crate plotlib;
-
 use plotlib::style::Point;
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,10 +75,6 @@ in this case, interpreting the bins and colours to create SVG elements.
 
 */
 
-extern crate svg;
-#[macro_use]
-extern crate failure;
-
 pub mod page;
 pub mod representation;
 pub mod view;

--- a/src/representation.rs
+++ b/src/representation.rs
@@ -13,7 +13,6 @@ These points may then be layered with other SVG elements from other representati
 */
 
 use crate::axis;
-use crate::svg;
 
 /**
 A representation of data that is continuous in two dimensions.

--- a/src/view.rs
+++ b/src/view.rs
@@ -9,7 +9,7 @@ extent to plot and information about the axes. It knows how to render itself.
 use std;
 use std::f64;
 
-use svg;
+use failure::format_err;
 use svg::Node;
 
 use crate::axis;

--- a/tests/test_no_data.rs
+++ b/tests/test_no_data.rs
@@ -1,5 +1,3 @@
-extern crate plotlib;
-
 use plotlib::page::Page;
 use plotlib::scatter;
 use plotlib::scatter::Scatter;


### PR DESCRIPTION
Now we are using rust 2018 edition, we do not need any `extern crate`
lines.