### PR TITLE
Make 3 common style structs, remove style traits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Changed
+- Remove style traits and replace all style structs with 3 common ones in `style`
 
 ## 0.4.0 - 2019-03-02
 ### Added

--- a/examples/barchart_svg.rs
+++ b/examples/barchart_svg.rs
@@ -1,10 +1,8 @@
-use plotlib::style::BarChart;
-
 fn main() {
     let b1 = plotlib::barchart::BarChart::new(5.3).label("1");
     let b2 = plotlib::barchart::BarChart::new(2.6)
         .label("2")
-        .style(plotlib::barchart::Style::new().fill("darkolivegreen"));
+        .style(plotlib::style::BoxStyle::new().fill("darkolivegreen"));
     let v = plotlib::view::CategoricalView::new()
         .add(&b1)
         .add(&b2)

--- a/examples/boxplot_svg.rs
+++ b/examples/boxplot_svg.rs
@@ -1,11 +1,9 @@
-use plotlib::style::BoxPlot;
-
 fn main() {
     let b1 = plotlib::boxplot::BoxPlot::from_slice(&[1.0, 4.0, 2.0, 3.5, 6.4, 2.5, 7.5, 1.8, 9.6])
         .label("1");
     let b2 = plotlib::boxplot::BoxPlot::from_slice(&[3.0, 4.3, 2.0, 3.5, 6.9, 4.5, 7.5, 1.8, 10.6])
         .label("2")
-        .style(plotlib::boxplot::Style::new().fill("darkolivegreen"));
+        .style(plotlib::style::BoxStyle::new().fill("darkolivegreen"));
     let v = plotlib::view::CategoricalView::new()
         .add(&b1)
         .add(&b2)

--- a/examples/function_svg.rs
+++ b/examples/function_svg.rs
@@ -1,15 +1,13 @@
-use plotlib::style::Line;
-
 fn main() {
     let f1 = plotlib::function::Function::new(|x| x * 5., 0., 10.)
-        .style(plotlib::function::Style::new().colour("burlywood"));
+        .style(plotlib::style::LineStyle::new().colour("burlywood"));
     let f2 = plotlib::function::Function::new(|x| x.powi(2), 0., 10.).style(
-        plotlib::function::Style::new()
+        plotlib::style::LineStyle::new()
             .colour("darkolivegreen")
             .width(2.),
     );
     let f3 = plotlib::function::Function::new(|x| x.sqrt() * 20., 0., 10.)
-        .style(plotlib::function::Style::new().colour("brown").width(1.));
+        .style(plotlib::style::LineStyle::new().colour("brown").width(1.));
     let v = plotlib::view::ContinuousView::new()
         .add(&f1)
         .add(&f2)

--- a/examples/histogram_svg.rs
+++ b/examples/histogram_svg.rs
@@ -1,9 +1,7 @@
-use plotlib::style::Bar;
-
 fn main() {
     let data = [0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
     let h = plotlib::histogram::Histogram::from_slice(&data, plotlib::histogram::Bins::Count(10))
-        .style(plotlib::histogram::Style::new().fill("burlywood"));
+        .style(plotlib::style::BoxStyle::new().fill("burlywood"));
     let v = plotlib::view::ContinuousView::new().add(&h);
     plotlib::page::Page::single(&v)
         .save("histogram.svg")

--- a/examples/line_svg.rs
+++ b/examples/line_svg.rs
@@ -1,8 +1,6 @@
-use plotlib::style::Line;
-
 fn main() {
     let l1 = plotlib::line::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
-        .style(plotlib::line::Style::new().colour("burlywood"));
+        .style(plotlib::style::LineStyle::new().colour("burlywood"));
     let v = plotlib::view::ContinuousView::new().add(&l1);
     plotlib::page::Page::single(&v)
         .save("line.svg")

--- a/examples/scatter_svg.rs
+++ b/examples/scatter_svg.rs
@@ -1,4 +1,4 @@
-use plotlib::style::Point;
+use plotlib::style::PointStyle;
 
 fn main() {
     let data = [
@@ -10,13 +10,13 @@ fn main() {
         (8.5, 3.7),
     ];
     let s1 = plotlib::scatter::Scatter::from_slice(&data).style(
-        plotlib::scatter::Style::new()
-            .marker(plotlib::style::Marker::Square)
+        plotlib::style::PointStyle::new()
+            .marker(plotlib::style::PointMarker::Square)
             .colour("burlywood")
             .size(2.),
     );
     let s2 = plotlib::scatter::Scatter::from_slice(&[(-1.4, 2.5), (7.2, -0.3)])
-        .style(plotlib::scatter::Style::new().colour("darkseagreen"));
+        .style(PointStyle::new().colour("darkseagreen"));
     let v = plotlib::view::ContinuousView::new()
         .add(&s1)
         .add(&s2)
@@ -35,7 +35,7 @@ fn main() {
         .data(data)
         .y_errors(errors)
         .colour(Colour::Red)
-        .marker(Marker::Circle);
+        .marker(PointMarker::Circle);
 
     // Create a histogram representation
     let h = Histogram::new()

--- a/examples/scatter_text.rs
+++ b/examples/scatter_text.rs
@@ -1,4 +1,3 @@
-use plotlib::style::Point;
 
 fn main() {
     let data = [
@@ -11,7 +10,7 @@ fn main() {
     ];
     let s1 = plotlib::scatter::Scatter::from_slice(&data);
     let s2 = plotlib::scatter::Scatter::from_slice(&[(-1.4, 2.5), (7.2, -0.3)])
-        .style(plotlib::scatter::Style::new().marker(plotlib::style::Marker::Square));
+        .style(plotlib::style::PointStyle::new().marker(plotlib::style::PointMarker::Square));
     let v = plotlib::view::ContinuousView::new()
         .add(&s1)
         .add(&s2)

--- a/examples/with_grid.rs
+++ b/examples/with_grid.rs
@@ -1,8 +1,6 @@
 extern crate plotlib;
 
 use plotlib::grid::Grid;
-use plotlib::style::BarChart;
-use plotlib::style::Line;
 use plotlib::view::View;
 
 fn main() {
@@ -15,7 +13,7 @@ where
     S: AsRef<str>,
 {
     let l1 = plotlib::line::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
-        .style(plotlib::line::Style::new().colour("burlywood"));
+        .style(plotlib::style::LineStyle::new().colour("burlywood"));
     let mut v = plotlib::view::ContinuousView::new().add(&l1);
     v.add_grid(Grid::new(3, 8));
     plotlib::page::Page::single(&v)
@@ -30,7 +28,7 @@ where
     let b1 = plotlib::barchart::BarChart::new(5.3).label("1");
     let b2 = plotlib::barchart::BarChart::new(2.6)
         .label("2")
-        .style(plotlib::barchart::Style::new().fill("darkolivegreen"));
+        .style(plotlib::style::BoxStyle::new().fill("darkolivegreen"));
     let mut v = plotlib::view::CategoricalView::new()
         .add(&b1)
         .add(&b2)

--- a/src/barchart.rs
+++ b/src/barchart.rs
@@ -19,61 +19,31 @@ use svg;
 
 use crate::axis;
 use crate::representation::CategoricalRepresentation;
-use crate::style;
+use crate::style::BoxStyle;
 use crate::svg_render;
-
-#[derive(Debug, Default)]
-pub struct Style {
-    fill: Option<String>,
-}
-
-impl Style {
-    pub fn new() -> Self {
-        Style { fill: None }
-    }
-
-    pub fn overlay(&mut self, other: &Self) {
-        if let Some(ref v) = other.fill {
-            self.fill = Some(v.clone())
-        }
-    }
-}
-
-impl style::BarChart for Style {
-    fn fill<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<String>,
-    {
-        self.fill = Some(value.into());
-        self
-    }
-
-    fn get_fill(&self) -> &Option<String> {
-        &self.fill
-    }
-}
 
 pub struct BarChart {
     value: f64,
     label: String,
-    style: Style,
+    style: BoxStyle,
 }
 
 impl BarChart {
     pub fn new(v: f64) -> Self {
         BarChart {
             value: v,
-            style: Style::new(),
+            style: BoxStyle::new(),
             label: String::new(),
         }
     }
 
-    pub fn style(mut self, style: &Style) -> Self {
+    pub fn style(mut self, style: &BoxStyle) -> Self {
         self.style.overlay(style);
         self
     }
 
-    pub fn get_style(&self) -> &Style {
+    pub fn get_style(&self) -> &BoxStyle {
+
         &self.style
     }
 

--- a/src/boxplot.rs
+++ b/src/boxplot.rs
@@ -19,40 +19,9 @@ use svg;
 
 use crate::axis;
 use crate::representation::CategoricalRepresentation;
-use crate::style;
+use crate::style::BoxStyle;
 use crate::svg_render;
 use crate::utils;
-
-#[derive(Debug, Default)]
-pub struct Style {
-    fill: Option<String>,
-}
-
-impl Style {
-    pub fn new() -> Self {
-        Style { fill: None }
-    }
-
-    pub fn overlay(&mut self, other: &Self) {
-        if let Some(ref v) = other.fill {
-            self.fill = Some(v.clone())
-        }
-    }
-}
-
-impl style::BoxPlot for Style {
-    fn fill<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<String>,
-    {
-        self.fill = Some(value.into());
-        self
-    }
-
-    fn get_fill(&self) -> &Option<String> {
-        &self.fill
-    }
-}
 
 enum BoxData<'a> {
     Owned(Vec<f64>),
@@ -62,14 +31,14 @@ enum BoxData<'a> {
 pub struct BoxPlot<'a> {
     data: BoxData<'a>,
     label: String,
-    style: Style,
+    style: BoxStyle,
 }
 
 impl<'a> BoxPlot<'a> {
     pub fn from_slice(v: &'a [(f64)]) -> Self {
         BoxPlot {
             data: BoxData::Ref(v),
-            style: Style::new(),
+            style: BoxStyle::new(),
             label: String::new(),
         }
     }
@@ -77,17 +46,17 @@ impl<'a> BoxPlot<'a> {
     pub fn from_vec(v: Vec<f64>) -> Self {
         BoxPlot {
             data: BoxData::Owned(v),
-            style: Style::new(),
+            style: BoxStyle::new(),
             label: String::new(),
         }
     }
 
-    pub fn style(mut self, style: &Style) -> Self {
+    pub fn style(mut self, style: &BoxStyle) -> Self {
         self.style.overlay(style);
         self
     }
 
-    pub fn get_style(&self) -> &Style {
+    pub fn get_style(&self) -> &BoxStyle {
         &self.style
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -19,63 +19,12 @@ use svg;
 
 use crate::axis;
 use crate::representation::ContinuousRepresentation;
-use crate::style;
+use crate::style::LineStyle;
 use crate::svg_render;
-
-#[derive(Debug, Default)]
-pub struct Style {
-    colour: Option<String>,
-    width: Option<f32>,
-}
-
-impl Style {
-    pub fn new() -> Self {
-        Style {
-            colour: None,
-            width: None,
-        }
-    }
-
-    pub fn overlay(&mut self, other: &Self) {
-        if let Some(ref v) = other.colour {
-            self.colour = Some(v.clone())
-        }
-
-        if let Some(v) = other.width {
-            self.width = Some(v)
-        }
-    }
-}
-
-impl style::Line for Style {
-    fn colour<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<String>,
-    {
-        self.colour = Some(value.into());
-        self
-    }
-
-    fn get_colour(&self) -> &Option<String> {
-        &self.colour
-    }
-
-    fn width<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<f32>,
-    {
-        self.width = Some(value.into());
-        self
-    }
-
-    fn get_width(&self) -> &Option<f32> {
-        &self.width
-    }
-}
 
 pub struct Function {
     pub data: Vec<(f64, f64)>,
-    style: Style,
+    style: LineStyle,
 }
 
 impl Function {
@@ -90,16 +39,16 @@ impl Function {
         let values = samples.map(|s| (s, f(s))).collect();
         Function {
             data: values,
-            style: Style::new(),
+            style: LineStyle::new(),
         }
     }
 
-    pub fn style(mut self, style: &Style) -> Self {
+    pub fn style(mut self, style: &LineStyle) -> Self {
         self.style.overlay(style);
         self
     }
 
-    pub fn get_style(&self) -> &Style {
+    pub fn get_style(&self) -> &LineStyle {
         &self.style
     }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -15,11 +15,11 @@
 //! ```rust
 //! # use plotlib::view::ContinuousView;
 //! use plotlib::grid::Grid;
-//! # use plotlib::style::Line;
+//! # use plotlib::style::LineStyle;
 //! # use plotlib::view::View;
 //!
 //! # let l1 = plotlib::line::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
-//! #    .style(plotlib::line::Style::new().colour("burlywood"));
+//! #    .style(LineStyle::new().colour("burlywood"));
 //! // let l1 = Line::new() ...
 //! let mut v = ContinuousView::new().add(&l1);
 //!

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -26,41 +26,11 @@ use svg;
 
 use crate::axis;
 use crate::representation::ContinuousRepresentation;
-use crate::style;
+use crate::style::BoxStyle;
 use crate::svg_render;
 use crate::text_render;
 use crate::utils::PairWise;
 
-#[derive(Debug, Default)]
-pub struct Style {
-    fill: Option<String>,
-}
-
-impl Style {
-    pub fn new() -> Self {
-        Style { fill: None }
-    }
-
-    pub fn overlay(&mut self, other: &Self) {
-        if let Some(ref v) = other.fill {
-            self.fill = Some(v.clone())
-        }
-    }
-}
-
-impl style::Bar for Style {
-    fn fill<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<String>,
-    {
-        self.fill = Some(value.into());
-        self
-    }
-
-    fn get_fill(&self) -> &Option<String> {
-        &self.fill
-    }
-}
 
 #[derive(Debug)]
 enum HistogramType {
@@ -82,7 +52,7 @@ pub struct Histogram {
     pub bin_bounds: Vec<f64>,    // will have N_bins + 1 entries
     pub bin_counts: Vec<f64>,    // will have N_bins entries
     pub bin_densities: Vec<f64>, // will have N_bins entries
-    style: Style,
+    style: BoxStyle,
     h_type: HistogramType,
 }
 
@@ -128,7 +98,7 @@ impl Histogram {
             bin_bounds: bounds,
             bin_counts: bins.iter().map(|&x| f64::from(x)).collect(),
             bin_densities: density_per_bin,
-            style: Style::new(),
+            style: BoxStyle::new(),
             h_type: HistogramType::Count,
         }
     }
@@ -152,7 +122,7 @@ impl Histogram {
         (0., max)
     }
 
-    pub fn style(mut self, style: &Style) -> Self {
+    pub fn style(mut self, style: &BoxStyle) -> Self {
         self.style.overlay(style);
         self
     }
@@ -165,7 +135,7 @@ impl Histogram {
         self
     }
 
-    pub fn get_style(&self) -> &Style {
+    pub fn get_style(&self) -> &BoxStyle {
         &self.style
     }
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -19,79 +19,28 @@ use svg;
 
 use crate::axis;
 use crate::representation::ContinuousRepresentation;
-use crate::style;
+use crate::style::LineStyle;
 use crate::svg_render;
-
-#[derive(Debug, Default)]
-pub struct Style {
-    colour: Option<String>,
-    width: Option<f32>,
-}
-
-impl Style {
-    pub fn new() -> Self {
-        Style {
-            colour: None,
-            width: None,
-        }
-    }
-
-    pub fn overlay(&mut self, other: &Self) {
-        if let Some(ref v) = other.colour {
-            self.colour = Some(v.clone())
-        }
-
-        if let Some(ref v) = other.width {
-            self.width = Some(*v)
-        }
-    }
-}
-
-impl style::Line for Style {
-    fn colour<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<String>,
-    {
-        self.colour = Some(value.into());
-        self
-    }
-
-    fn get_colour(&self) -> &Option<String> {
-        &self.colour
-    }
-
-    fn width<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<f32>,
-    {
-        self.width = Some(value.into());
-        self
-    }
-
-    fn get_width(&self) -> &Option<f32> {
-        &self.width
-    }
-}
 
 pub struct Line {
     pub data: Vec<(f64, f64)>,
-    style: Style,
+    style: LineStyle,
 }
 
 impl Line {
     pub fn new(v: &[(f64, f64)]) -> Self {
         Line {
             data: v.into(),
-            style: Style::new(),
+            style: LineStyle::new(),
         }
     }
 
-    pub fn style(mut self, style: &Style) -> Self {
+    pub fn style(mut self, style: &LineStyle) -> Self {
         self.style.overlay(style);
         self
     }
 
-    pub fn get_style(&self) -> &Style {
+    pub fn get_style(&self) -> &LineStyle {
         &self.style
     }
 

--- a/src/scatter.rs
+++ b/src/scatter.rs
@@ -4,90 +4,16 @@ use svg;
 
 use crate::axis;
 use crate::representation::ContinuousRepresentation;
-use crate::style;
+use crate::style::PointStyle;
 use crate::svg_render;
 use crate::text_render;
-
-/// `Style` follows the 'optional builder' pattern
-/// Each field is a `Option` which start as `None`
-/// Each can be set with setter methods and instances
-/// of `Style` can be overlaid to set many at once.
-/// Settings will be cloned in and out of it.
-#[derive(Debug, Default)]
-pub struct Style {
-    marker: Option<style::Marker>,
-    colour: Option<String>,
-    size: Option<f32>,
-}
-
-impl Style {
-    pub fn new() -> Self {
-        Style {
-            marker: None,
-            colour: None,
-            size: None,
-        }
-    }
-
-    pub fn overlay(&mut self, other: &Self) {
-        if let Some(ref v) = other.marker {
-            self.marker = Some(v.clone())
-        }
-
-        if let Some(ref v) = other.colour {
-            self.colour = Some(v.clone())
-        }
-
-        if let Some(v) = other.size {
-            self.size = Some(v)
-        }
-    }
-}
-
-impl style::Point for Style {
-    fn marker<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<style::Marker>,
-    {
-        self.marker = Some(value.into());
-        self
-    }
-
-    fn get_marker(&self) -> &Option<style::Marker> {
-        &self.marker
-    }
-
-    fn colour<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<String>,
-    {
-        self.colour = Some(value.into());
-        self
-    }
-
-    fn get_colour(&self) -> &Option<String> {
-        &self.colour
-    }
-
-    fn size<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<f32>,
-    {
-        self.size = Some(value.into());
-        self
-    }
-
-    fn get_size(&self) -> &Option<f32> {
-        &self.size
-    }
-}
 
 /// The scatter *representation*.
 /// It knows its data as well how to style itself
 #[derive(Debug)]
 pub struct Scatter {
     pub data: Vec<(f64, f64)>,
-    style: Style,
+    style: PointStyle,
 }
 
 impl Scatter {
@@ -99,16 +25,16 @@ impl Scatter {
 
         Scatter {
             data,
-            style: Style::new(),
+            style: PointStyle::new(),
         }
     }
 
-    pub fn style(mut self, style: &Style) -> Self {
+    pub fn style(mut self, style: &PointStyle) -> Self {
         self.style.overlay(style);
         self
     }
 
-    pub fn get_style(&self) -> &Style {
+    pub fn get_style(&self) -> &PointStyle {
         &self.style
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,73 +1,159 @@
-/*!
+//! Manage how elements should be drawn
 
-Manage how elements should be drawn
+//! All style structs follows the 'optional builder' pattern:
+//! Each field is a `Option` which start as `None`.
+//! They can all be set with setter methods, and instances
+//! can be overlaid with another one to set many at once.
+//! Settings will be cloned in and out of it.
 
-*/
+#[derive(Debug, Default)]
+pub struct LineStyle {
+    colour: Option<String>,
+    width: Option<f32>,
+}
+impl LineStyle {
+    pub fn new() -> Self {
+        LineStyle {
+            colour: None,
+            width: None,
+        }
+    }
 
-pub trait Line {
-    fn colour<T>(&mut self, value: T) -> &mut Self
+    pub fn overlay(&mut self, other: &Self) {
+        if let Some(ref v) = other.colour {
+            self.colour = Some(v.clone())
+        }
+
+        if let Some(ref v) = other.width {
+            self.width = Some(*v)
+        }
+    }
+    pub fn colour<T>(&mut self, value: T) -> &mut Self
     where
-        T: Into<String>;
+        T: Into<String>,
+    {
+        self.colour = Some(value.into());
+        self
+    }
 
-    fn get_colour(&self) -> &Option<String>;
+    pub fn get_colour(&self) -> &Option<String> {
+        &self.colour
+    }
 
-    fn width<T>(&mut self, value: T) -> &mut Self
+    pub fn width<T>(&mut self, value: T) -> &mut Self
     where
-        T: Into<f32>;
+        T: Into<f32>,
+    {
+        self.width = Some(value.into());
+        self
+    }
 
-    fn get_width(&self) -> &Option<f32>;
+    pub fn get_width(&self) -> &Option<f32> {
+        &self.width
+    }
 }
 
 /**
 The marker that should be used for the points of the scatter plot
 */
 #[derive(Debug, Clone)]
-pub enum Marker {
+pub enum PointMarker {
     Circle,
     Square,
     Cross,
 }
 
-pub trait Point {
-    fn marker<T>(&mut self, value: T) -> &mut Self
+
+#[derive(Debug, Default)]
+pub struct PointStyle {
+    marker: Option<PointMarker>,
+    colour: Option<String>,
+    size: Option<f32>,
+}
+impl PointStyle {
+    pub fn new() -> Self {
+        PointStyle {
+            marker: None,
+            colour: None,
+            size: None,
+        }
+    }
+
+    pub fn overlay(&mut self, other: &Self) {
+        if let Some(ref v) = other.marker {
+            self.marker = Some(v.clone())
+        }
+
+        if let Some(ref v) = other.colour {
+            self.colour = Some(v.clone())
+        }
+
+        if let Some(v) = other.size {
+            self.size = Some(v)
+        }
+    }
+    pub fn marker<T>(&mut self, value: T) -> &mut Self
     where
-        T: Into<Marker>;
+        T: Into<PointMarker>,
+    {
+        self.marker = Some(value.into());
+        self
+    }
 
-    fn get_marker(&self) -> &Option<Marker>;
+    pub fn get_marker(&self) -> &Option<PointMarker> {
+        &self.marker
+    }
 
-    fn colour<T>(&mut self, value: T) -> &mut Self
+    pub fn colour<T>(&mut self, value: T) -> &mut Self
     where
-        T: Into<String>;
+        T: Into<String>,
+    {
+        self.colour = Some(value.into());
+        self
+    }
 
-    fn get_colour(&self) -> &Option<String>;
+    pub fn get_colour(&self) -> &Option<String> {
+        &self.colour
+    }
 
-    fn size<T>(&mut self, value: T) -> &mut Self
+    pub fn size<T>(&mut self, value: T) -> &mut Self
     where
-        T: Into<f32>;
+        T: Into<f32>,
+    {
+        self.size = Some(value.into());
+        self
+    }
 
-    fn get_size(&self) -> &Option<f32>;
+    pub fn get_size(&self) -> &Option<f32> {
+        &self.size
+    }
 }
 
-pub trait Bar {
-    fn fill<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<String>;
 
-    fn get_fill(&self) -> &Option<String>;
+#[derive(Debug, Default)]
+pub struct BoxStyle {
+    fill: Option<String>,
 }
+impl BoxStyle {
+    pub fn new() -> Self {
+        BoxStyle { fill: None }
+    }
 
-pub trait BoxPlot {
-    fn fill<T>(&mut self, value: T) -> &mut Self
+    pub fn overlay(&mut self, other: &Self) {
+        if let Some(ref v) = other.fill {
+            self.fill = Some(v.clone())
+        }
+    }
+
+    pub fn fill<T>(&mut self, value: T) -> &mut Self
     where
-        T: Into<String>;
+        T: Into<String>,
+    {
+        self.fill = Some(value.into());
+        self
+    }
 
-    fn get_fill(&self) -> &Option<String>;
-}
-
-pub trait BarChart {
-    fn fill<T>(&mut self, value: T) -> &mut Self
-    where
-        T: Into<String>;
-
-    fn get_fill(&self) -> &Option<String>;
+    pub fn get_fill(&self) -> &Option<String> {
+        &self.fill
+    }
 }

--- a/src/svg_render.rs
+++ b/src/svg_render.rs
@@ -174,16 +174,14 @@ pub fn draw_categorical_x_axis(a: &axis::CategoricalAxis, face_width: f64) -> no
         .add(label)
 }
 
-pub fn draw_face_points<S>(
+pub fn draw_face_points(
     s: &[(f64, f64)],
     x_axis: &axis::ContinuousAxis,
     y_axis: &axis::ContinuousAxis,
     face_width: f64,
     face_height: f64,
-    style: &S,
+    style: &style::PointStyle,
 ) -> node::element::Group
-where
-    S: style::Point,
 {
     let mut group = node::element::Group::new();
 
@@ -191,8 +189,8 @@ where
         let x_pos = value_to_face_offset(x, x_axis, face_width);
         let y_pos = -value_to_face_offset(y, y_axis, face_height);
         let radius = f64::from(style.get_size().clone().unwrap_or(5.));
-        match style.get_marker().clone().unwrap_or(style::Marker::Circle) {
-            style::Marker::Circle => {
+        match style.get_marker().clone().unwrap_or(style::PointMarker::Circle) {
+            style::PointMarker::Circle => {
                 group.append(
                     node::element::Circle::new()
                         .set("cx", x_pos)
@@ -204,7 +202,7 @@ where
                         ),
                 );
             }
-            style::Marker::Square => {
+            style::PointMarker::Square => {
                 group.append(
                     node::element::Rectangle::new()
                         .set("x", x_pos - radius)
@@ -217,7 +215,7 @@ where
                         ),
                 );
             }
-            style::Marker::Cross => {
+            style::PointMarker::Cross => {
                 let path = node::element::path::Data::new()
                     .move_to((x_pos - radius, y_pos - radius))
                     .line_by((radius * 2., radius * 2.))
@@ -241,16 +239,14 @@ where
     group
 }
 
-pub fn draw_face_bars<S>(
+pub fn draw_face_bars(
     h: &histogram::Histogram,
     x_axis: &axis::ContinuousAxis,
     y_axis: &axis::ContinuousAxis,
     face_width: f64,
     face_height: f64,
-    style: &S,
+    style: &style::BoxStyle,
 ) -> node::element::Group
-where
-    S: style::Bar,
 {
     let mut group = node::element::Group::new();
 
@@ -278,16 +274,14 @@ where
     group
 }
 
-pub fn draw_face_line<S>(
+pub fn draw_face_line(
     s: &[(f64, f64)],
     x_axis: &axis::ContinuousAxis,
     y_axis: &axis::ContinuousAxis,
     face_width: f64,
     face_height: f64,
-    style: &S,
+    style: &style::LineStyle,
 ) -> node::element::Group
-where
-    S: style::Line,
 {
     let mut group = node::element::Group::new();
 
@@ -324,17 +318,16 @@ where
     group
 }
 
-pub fn draw_face_boxplot<L, S>(
+pub fn draw_face_boxplot<L>(
     d: &[f64],
     label: &L,
     x_axis: &axis::CategoricalAxis,
     y_axis: &axis::ContinuousAxis,
     face_width: f64,
     face_height: f64,
-    style: &S,
+    style: &style::BoxStyle,
 ) -> node::element::Group
 where
-    S: style::BoxPlot,
     L: Into<String>,
     String: std::cmp::PartialEq<L>,
 {
@@ -404,17 +397,16 @@ where
     group
 }
 
-pub fn draw_face_barchart<L, S>(
+pub fn draw_face_barchart<L>(
     d: f64,
     label: &L,
     x_axis: &axis::CategoricalAxis,
     y_axis: &axis::ContinuousAxis,
     face_width: f64,
     face_height: f64,
-    style: &S,
+    style: &style::BoxStyle,
 ) -> node::element::Group
 where
-    S: style::BarChart,
     L: Into<String>,
     String: std::cmp::PartialEq<L>,
 {

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -343,16 +343,14 @@ pub fn render_face_bars(
 /// the x ands y-axes
 /// and the face height and width,
 /// create the strings to be drawn as the face
-pub fn render_face_points<S>(
+pub fn render_face_points(
     s: &[(f64, f64)],
     x_axis: &axis::ContinuousAxis,
     y_axis: &axis::ContinuousAxis,
     face_width: u32,
     face_height: u32,
-    style: &S,
+    style: &style::PointStyle,
 ) -> String
-where
-    S: style::Point,
 {
     let points: Vec<_> = s
         .iter()
@@ -363,10 +361,10 @@ where
             )
         }).collect();
 
-    let marker = match style.get_marker().clone().unwrap_or(style::Marker::Circle) {
-        style::Marker::Circle => '●',
-        style::Marker::Square => '■',
-        style::Marker::Cross => '×',
+    let marker = match style.get_marker().clone().unwrap_or(style::PointMarker::Circle) {
+        style::PointMarker::Circle => '●',
+        style::PointMarker::Square => '■',
+        style::PointMarker::Cross => '×',
     };
 
     let mut face_strings: Vec<String> = vec![];
@@ -619,6 +617,7 @@ mod tests {
     #[test]
     fn test_render_face_points() {
         use crate::scatter;
+        use crate::style::PointStyle;
         let data = vec![
             (-3.0, 2.3),
             (-1.6, 5.3),
@@ -630,7 +629,7 @@ mod tests {
         let s = scatter::Scatter::from_slice(&data);
         let x_axis = axis::ContinuousAxis::new(-3.575, 9.075);
         let y_axis = axis::ContinuousAxis::new(-1.735, 5.635);
-        let style = scatter::Style::new();
+        let style = PointStyle::new();
         let strings = render_face_points(&s.data, &x_axis, &y_axis, 20, 10, &style);
         assert_eq!(strings.lines().count(), 10);
         assert!(strings.lines().all(|s| s.chars().count() == 20));

--- a/tests/test_no_data.rs
+++ b/tests/test_no_data.rs
@@ -1,7 +1,6 @@
 use plotlib::page::Page;
-use plotlib::scatter;
 use plotlib::scatter::Scatter;
-use plotlib::style::{Marker, Point};
+use plotlib::style::{PointMarker, PointStyle};
 use plotlib::view::ContinuousView;
 
 #[test]
@@ -11,8 +10,8 @@ fn test_data_with_one_length() {
 
     // We create our scatter plot from the data
     let s1 = Scatter::from_slice(&data1).style(
-        scatter::Style::new()
-            .marker(Marker::Square) // setting the marker to be a square
+        PointStyle::new()
+            .marker(PointMarker::Square) // setting the marker to be a square
             .colour("#DD3355"),
     ); // and a custom colour
 
@@ -37,8 +36,8 @@ fn test_data_with_no_length() {
 
     // We create our scatter plot from the data
     let s1 = Scatter::from_slice(&data1).style(
-        scatter::Style::new()
-            .marker(Marker::Square) // setting the marker to be a square
+        PointStyle::new()
+            .marker(PointMarker::Square) // setting the marker to be a square
             .colour("#DD3355"),
     ); // and a custom colour
 
@@ -64,8 +63,8 @@ fn test_data_with_one_length_and_autoscaling_axes_limits() {
 
     // We create our scatter plot from the data
     let s1 = Scatter::from_slice(&data1).style(
-        scatter::Style::new()
-            .marker(Marker::Square) // setting the marker to be a square
+        PointStyle::new()
+            .marker(PointMarker::Square) // setting the marker to be a square
             .colour("#DD3355"),
     ); // and a custom colour
 


### PR DESCRIPTION
This should simplify the interface somewhat. I don't think we should bother with traits and generics of styles before we see the necessity of it.

- [x] Remove style traits and replace all style structs with 3 common ones in `style`.
- [x] Examples compile, tests pass
- [x] Added an entry to the CHANGELOG file