### PR TITLE
Repr module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Changed
 - Remove style traits and replace all style structs with 3 common ones in `style`
+- Group all representations under a `repr` module.
 
 ## 0.4.0 - 2019-03-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ The API is still very much in flux and is subject to change.
 For example, code like:
 
 ```rust
-use plotlib::scatter::Scatter;
-use plotlib::scatter;
-use plotlib::style::{Marker, Point};
+use plotlib::repr;
+use plotlib::style;
 use plotlib::view::View;
 use plotlib::page::Page;
 
@@ -34,14 +33,14 @@ fn main() {
 
     // We create our scatter plot from the data
     let s1 = Scatter::from_slice(&data1)
-        .style(scatter::Style::new()
-            .marker(Marker::Square) // setting the marker to be a square
+        .style(style::PointStyle::new()
+            .marker(style::PointMarker::Square) // setting the marker to be a square
             .colour("#DD3355")); // and a custom colour
 
     // We can plot multiple data sets in the same view
     let data2 = [(-1.4, 2.5), (7.2, -0.3)];
     let s2 = Scatter::from_slice(&data2)
-        .style(scatter::Style::new() // uses the default marker
+        .style(style::PointStyle::new() // uses the default marker
             .colour("#35C788")); // and a different colour
 
     // The 'view' describes what set of data is drawn

--- a/examples/barchart_svg.rs
+++ b/examples/barchart_svg.rs
@@ -1,6 +1,6 @@
 fn main() {
-    let b1 = plotlib::barchart::BarChart::new(5.3).label("1");
-    let b2 = plotlib::barchart::BarChart::new(2.6)
+    let b1 = plotlib::repr::BarChart::new(5.3).label("1");
+    let b2 = plotlib::repr::BarChart::new(2.6)
         .label("2")
         .style(plotlib::style::BoxStyle::new().fill("darkolivegreen"));
     let v = plotlib::view::CategoricalView::new()

--- a/examples/boxplot_svg.rs
+++ b/examples/boxplot_svg.rs
@@ -1,7 +1,7 @@
 fn main() {
-    let b1 = plotlib::boxplot::BoxPlot::from_slice(&[1.0, 4.0, 2.0, 3.5, 6.4, 2.5, 7.5, 1.8, 9.6])
+    let b1 = plotlib::repr::BoxPlot::from_slice(&[1.0, 4.0, 2.0, 3.5, 6.4, 2.5, 7.5, 1.8, 9.6])
         .label("1");
-    let b2 = plotlib::boxplot::BoxPlot::from_slice(&[3.0, 4.3, 2.0, 3.5, 6.9, 4.5, 7.5, 1.8, 10.6])
+    let b2 = plotlib::repr::BoxPlot::from_slice(&[3.0, 4.3, 2.0, 3.5, 6.9, 4.5, 7.5, 1.8, 10.6])
         .label("2")
         .style(plotlib::style::BoxStyle::new().fill("darkolivegreen"));
     let v = plotlib::view::CategoricalView::new()

--- a/examples/function_svg.rs
+++ b/examples/function_svg.rs
@@ -1,13 +1,14 @@
+use plotlib::{repr, style};
 fn main() {
-    let f1 = plotlib::function::Function::new(|x| x * 5., 0., 10.)
-        .style(plotlib::style::LineStyle::new().colour("burlywood"));
-    let f2 = plotlib::function::Function::new(|x| x.powi(2), 0., 10.).style(
-        plotlib::style::LineStyle::new()
+    let f1 = repr::Function::new(|x| x * 5., 0., 10.)
+        .style(style::LineStyle::new().colour("burlywood"));
+    let f2 = repr::Function::new(|x| x.powi(2), 0., 10.).style(
+        style::LineStyle::new()
             .colour("darkolivegreen")
             .width(2.),
     );
-    let f3 = plotlib::function::Function::new(|x| x.sqrt() * 20., 0., 10.)
-        .style(plotlib::style::LineStyle::new().colour("brown").width(1.));
+    let f3 = repr::Function::new(|x| x.sqrt() * 20., 0., 10.)
+        .style(style::LineStyle::new().colour("brown").width(1.));
     let v = plotlib::view::ContinuousView::new()
         .add(&f1)
         .add(&f2)

--- a/examples/histogram_svg.rs
+++ b/examples/histogram_svg.rs
@@ -1,6 +1,6 @@
 fn main() {
     let data = [0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
-    let h = plotlib::histogram::Histogram::from_slice(&data, plotlib::histogram::Bins::Count(10))
+    let h = plotlib::repr::Histogram::from_slice(&data, plotlib::repr::HistogramBins::Count(10))
         .style(plotlib::style::BoxStyle::new().fill("burlywood"));
     let v = plotlib::view::ContinuousView::new().add(&h);
     plotlib::page::Page::single(&v)

--- a/examples/histogram_text.rs
+++ b/examples/histogram_text.rs
@@ -1,6 +1,6 @@
 fn main() {
     let data = [0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
-    let h = plotlib::histogram::Histogram::from_slice(&data, plotlib::histogram::Bins::Count(10));
+    let h = plotlib::repr::Histogram::from_slice(&data, plotlib::repr::HistogramBins::Count(10));
     let v = plotlib::view::ContinuousView::new().add(&h);
     println!(
         "{}",

--- a/examples/line_svg.rs
+++ b/examples/line_svg.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let l1 = plotlib::line::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
+    let l1 = plotlib::repr::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
         .style(plotlib::style::LineStyle::new().colour("burlywood"));
     let v = plotlib::view::ContinuousView::new().add(&l1);
     plotlib::page::Page::single(&v)

--- a/examples/scatter_svg.rs
+++ b/examples/scatter_svg.rs
@@ -9,13 +9,13 @@ fn main() {
         (6.4, 4.3),
         (8.5, 3.7),
     ];
-    let s1 = plotlib::scatter::Scatter::from_slice(&data).style(
+    let s1 = plotlib::repr::Scatter::from_slice(&data).style(
         plotlib::style::PointStyle::new()
             .marker(plotlib::style::PointMarker::Square)
             .colour("burlywood")
             .size(2.),
     );
-    let s2 = plotlib::scatter::Scatter::from_slice(&[(-1.4, 2.5), (7.2, -0.3)])
+    let s2 = plotlib::repr::Scatter::from_slice(&[(-1.4, 2.5), (7.2, -0.3)])
         .style(PointStyle::new().colour("darkseagreen"));
     let v = plotlib::view::ContinuousView::new()
         .add(&s1)

--- a/examples/scatter_text.rs
+++ b/examples/scatter_text.rs
@@ -8,8 +8,8 @@ fn main() {
         (6.4, 4.3),
         (8.5, 3.7),
     ];
-    let s1 = plotlib::scatter::Scatter::from_slice(&data);
-    let s2 = plotlib::scatter::Scatter::from_slice(&[(-1.4, 2.5), (7.2, -0.3)])
+    let s1 = plotlib::repr::Scatter::from_slice(&data);
+    let s2 = plotlib::repr::Scatter::from_slice(&[(-1.4, 2.5), (7.2, -0.3)])
         .style(plotlib::style::PointStyle::new().marker(plotlib::style::PointMarker::Square));
     let v = plotlib::view::ContinuousView::new()
         .add(&s1)

--- a/examples/with_grid.rs
+++ b/examples/with_grid.rs
@@ -12,7 +12,7 @@ fn render_line_chart<S>(filename: S)
 where
     S: AsRef<str>,
 {
-    let l1 = plotlib::line::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
+    let l1 = plotlib::repr::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
         .style(plotlib::style::LineStyle::new().colour("burlywood"));
     let mut v = plotlib::view::ContinuousView::new().add(&l1);
     v.add_grid(Grid::new(3, 8));
@@ -25,8 +25,8 @@ fn render_barchart<S>(filename: S)
 where
     S: AsRef<str>,
 {
-    let b1 = plotlib::barchart::BarChart::new(5.3).label("1");
-    let b2 = plotlib::barchart::BarChart::new(2.6)
+    let b1 = plotlib::repr::BarChart::new(5.3).label("1");
+    let b2 = plotlib::repr::BarChart::new(2.6)
         .label("2")
         .style(plotlib::style::BoxStyle::new().fill("darkolivegreen"));
     let mut v = plotlib::view::CategoricalView::new()

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -18,7 +18,7 @@
 //! # use plotlib::style::LineStyle;
 //! # use plotlib::view::View;
 //!
-//! # let l1 = plotlib::line::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
+//! # let l1 = plotlib::repr::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
 //! #    .style(LineStyle::new().colour("burlywood"));
 //! // let l1 = Line::new() ...
 //! let mut v = ContinuousView::new().add(&l1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,11 @@ plotlib is a data plotting and rendering library.
 
 There are five different types of plot currently supported:
 
-1. Box plot (`plotlib::boxplot::Box`)
-1. Function (`plotlib::function::Function`)
-1. Histogram (`plotlib::histogram::Histogram`)
-1. Line chart (`plotlib::line::Line`)
-1. Scatter plot (`plotlib::scatter::Scatter`)
+1. Box plot (`plotlib::repr::Box`)
+1. Function (`plotlib::repr::Function`)
+1. Histogram (`plotlib::repr::Histogram`)
+1. Line chart (`plotlib::repr::Line`)
+1. Scatter plot (`plotlib::repr::Scatter`)
 
 ## Technical
 
@@ -76,19 +76,13 @@ in this case, interpreting the bins and colours to create SVG elements.
 */
 
 pub mod page;
-pub mod representation;
 pub mod view;
+pub mod grid;
+pub mod style;
+pub mod repr;
 
 mod axis;
-pub mod barchart;
-pub mod boxplot;
 mod errors;
-pub mod function;
-pub mod grid;
-pub mod histogram;
-pub mod line;
-pub mod scatter;
-pub mod style;
 mod svg_render;
 mod text_render;
 mod utils;

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,5 +1,5 @@
 use crate::scatter;
-use crate::histogram;
+use crate::repr;
 use crate::text_render;
 use crate::svg_render;
 
@@ -18,7 +18,7 @@ impl Render for scatter::Scatter {
     }
 }
 
-impl Render for histogram::Histogram {
+impl Render for repr::Histogram {
     fn to_text(&self) -> text_render::Text {
         text_render::Text {data: text_render::draw_histogram(self)}
     }

--- a/src/repr/barchart.rs
+++ b/src/repr/barchart.rs
@@ -5,7 +5,7 @@ Bar chart
 # Examples
 
 ```
-# use plotlib::barchart::BarChart;
+# use plotlib::repr::BarChart;
 # use plotlib::view::CategoricalView;
 let b1 = BarChart::new(5.2).label("b1");
 let b2 = BarChart::new(1.6).label("b2");
@@ -18,7 +18,7 @@ use std::f64;
 use svg;
 
 use crate::axis;
-use crate::representation::CategoricalRepresentation;
+use crate::repr::CategoricalRepresentation;
 use crate::style::BoxStyle;
 use crate::svg_render;
 

--- a/src/repr/boxplot.rs
+++ b/src/repr/boxplot.rs
@@ -5,7 +5,7 @@ Box plot
 # Examples
 
 ```
-# use plotlib::boxplot::BoxPlot;
+# use plotlib::repr::BoxPlot;
 # use plotlib::view::CategoricalView;
 let b1 = BoxPlot::from_slice(&[0., 2., 3., 4.]);
 let b2 = BoxPlot::from_vec(vec![0., 2., 3., 4.]);
@@ -18,7 +18,7 @@ use std::f64;
 use svg;
 
 use crate::axis;
-use crate::representation::CategoricalRepresentation;
+use crate::repr::CategoricalRepresentation;
 use crate::style::BoxStyle;
 use crate::svg_render;
 use crate::utils;

--- a/src/repr/function.rs
+++ b/src/repr/function.rs
@@ -1,40 +1,54 @@
+/*!
+
+Plot arbitrary functions
+
+# Examples
+
+```
+# use plotlib::repr::Function;
+# use plotlib::view::ContinuousView;
+// y=x^2 between 0 and 10
+let f = Function::new(|x| x*x, 0., 10.);
+let v = ContinuousView::new().add(&f);
+```
+*/
+
 use std::f64;
 
 use svg;
 
 use crate::axis;
-use crate::representation::ContinuousRepresentation;
-use crate::style::PointStyle;
+use crate::repr::ContinuousRepresentation;
+use crate::style::LineStyle;
 use crate::svg_render;
-use crate::text_render;
 
-/// The scatter *representation*.
-/// It knows its data as well how to style itself
-#[derive(Debug)]
-pub struct Scatter {
+pub struct Function {
     pub data: Vec<(f64, f64)>,
-    style: PointStyle,
+    style: LineStyle,
 }
 
-impl Scatter {
-    pub fn from_slice(v: &[(f64, f64)]) -> Self {
-        let mut data: Vec<(f64, f64)> = vec![];
-        for &(x, y) in v {
-            data.push((x, y));
-        }
-
-        Scatter {
-            data,
-            style: PointStyle::new(),
+impl Function {
+    pub fn new<F>(f: F, lower: f64, upper: f64) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
+        let sampling = (upper - lower) / 200.;
+        let samples = (0..)
+            .map(|x| lower + (f64::from(x) * sampling))
+            .take_while(|&x| x <= upper);
+        let values = samples.map(|s| (s, f(s))).collect();
+        Function {
+            data: values,
+            style: LineStyle::new(),
         }
     }
 
-    pub fn style(mut self, style: &PointStyle) -> Self {
+    pub fn style(mut self, style: &LineStyle) -> Self {
         self.style.overlay(style);
         self
     }
 
-    pub fn get_style(&self) -> &PointStyle {
+    pub fn get_style(&self) -> &LineStyle {
         &self.style
     }
 
@@ -59,7 +73,7 @@ impl Scatter {
     }
 }
 
-impl ContinuousRepresentation for Scatter {
+impl ContinuousRepresentation for Function {
     fn range(&self, dim: u32) -> (f64, f64) {
         match dim {
             0 => self.x_range(),
@@ -75,7 +89,7 @@ impl ContinuousRepresentation for Scatter {
         face_width: f64,
         face_height: f64,
     ) -> svg::node::element::Group {
-        svg_render::draw_face_points(
+        svg_render::draw_face_line(
             &self.data,
             x_axis,
             y_axis,
@@ -87,18 +101,11 @@ impl ContinuousRepresentation for Scatter {
 
     fn to_text(
         &self,
-        x_axis: &axis::ContinuousAxis,
-        y_axis: &axis::ContinuousAxis,
-        face_width: u32,
-        face_height: u32,
+        _x_axis: &axis::ContinuousAxis,
+        _y_axis: &axis::ContinuousAxis,
+        _face_width: u32,
+        _face_height: u32,
     ) -> String {
-        text_render::render_face_points(
-            &self.data,
-            x_axis,
-            y_axis,
-            face_width,
-            face_height,
-            &self.style,
-        )
+        "".into()
     }
 }

--- a/src/repr/histogram.rs
+++ b/src/repr/histogram.rs
@@ -5,12 +5,12 @@ A module for Histograms
 # Examples
 
 ```
-# use plotlib::histogram::Histogram;
+# use plotlib::repr::Histogram;
 // Create some dummy data
 let data = vec![0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
 
 // and create a histogram out of it
-let h = Histogram::from_slice(&data, plotlib::histogram::Bins::Count(30));
+let h = Histogram::from_slice(&data, plotlib::repr::HistogramBins::Count(30));
 ```
 
 TODO:
@@ -25,7 +25,7 @@ use std;
 use svg;
 
 use crate::axis;
-use crate::representation::ContinuousRepresentation;
+use crate::repr::ContinuousRepresentation;
 use crate::style::BoxStyle;
 use crate::svg_render;
 use crate::text_render;
@@ -39,7 +39,7 @@ enum HistogramType {
 }
 
 #[derive(Debug)]
-pub enum Bins {
+pub enum HistogramBins {
     Count(usize),
     Bounds(Vec<f64>),
 }
@@ -57,7 +57,7 @@ pub struct Histogram {
 }
 
 impl Histogram {
-    pub fn from_slice(v: &[f64], bins: Bins) -> Histogram {
+    pub fn from_slice(v: &[f64], bins: HistogramBins) -> Histogram {
         let mut max = v.iter().fold(-1. / 0., |a, &b| f64::max(a, b));
         let mut min = v.iter().fold(1. / 0., |a, &b| f64::min(a, b));
 
@@ -67,7 +67,7 @@ impl Histogram {
         }
 
         let (num_bins, bounds) = match bins {
-            Bins::Count(num_bins) => {
+            HistogramBins::Count(num_bins) => {
                 let range = max - min;
                 let mut bounds: Vec<f64> = (0..num_bins)
                     .map(|n| (n as f64 / num_bins as f64) * range + min)
@@ -75,7 +75,7 @@ impl Histogram {
                 bounds.push(max);
                 (num_bins, bounds)
             }
-            Bins::Bounds(bounds) => (bounds.len(), bounds),
+            HistogramBins::Bounds(bounds) => (bounds.len(), bounds),
         };
 
         let mut bins = vec![0; num_bins];
@@ -184,19 +184,19 @@ mod tests {
     #[test]
     fn test_histogram_from_slice() {
         assert_eq!(
-            Histogram::from_slice(&[], Bins::Count(3)).get_values(),
+            Histogram::from_slice(&[], HistogramBins::Count(3)).get_values(),
             [0., 0., 0.]
         );
         assert_eq!(
-            Histogram::from_slice(&[0.], Bins::Count(3)).get_values(),
+            Histogram::from_slice(&[0.], HistogramBins::Count(3)).get_values(),
             [0., 1., 0.]
         );
         assert_eq!(
-            Histogram::from_slice(&[0., 3.], Bins::Count(3)).get_values(),
+            Histogram::from_slice(&[0., 3.], HistogramBins::Count(3)).get_values(),
             [1., 0., 1.]
         );
         assert_eq!(
-            Histogram::from_slice(&[0., 1., 2., 3.], Bins::Count(3)).get_values(),
+            Histogram::from_slice(&[0., 1., 2., 3.], HistogramBins::Count(3)).get_values(),
             [2., 1., 1.]
         );
     }
@@ -204,11 +204,11 @@ mod tests {
     #[test]
     fn test_histogram_define_bin_bounds() {
         assert_eq!(
-            Histogram::from_slice(&[0., 1.], Bins::Count(3)).bin_bounds,
+            Histogram::from_slice(&[0., 1.], HistogramBins::Count(3)).bin_bounds,
             [0., 1. / 3., 2. / 3., 1.]
         );
         assert_eq!(
-            Histogram::from_slice(&[], Bins::Bounds([0., 1., 1.5, 2., 5.6].to_vec())).bin_bounds,
+            Histogram::from_slice(&[], HistogramBins::Bounds([0., 1., 1.5, 2., 5.6].to_vec())).bin_bounds,
             [0., 1., 1.5, 2., 5.6]
         );
     }

--- a/src/repr/line.rs
+++ b/src/repr/line.rs
@@ -5,7 +5,7 @@ Plot line charts
 # Examples
 
 ```
-# use plotlib::line::Line;
+# use plotlib::repr::Line;
 # use plotlib::view::ContinuousView;
 // y=x^2 between 0 and 10
 let l = Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)]);
@@ -18,7 +18,7 @@ use std::f64;
 use svg;
 
 use crate::axis;
-use crate::representation::ContinuousRepresentation;
+use crate::repr::ContinuousRepresentation;
 use crate::style::LineStyle;
 use crate::svg_render;
 

--- a/src/repr/mod.rs
+++ b/src/repr/mod.rs
@@ -14,6 +14,19 @@ These points may then be layered with other SVG elements from other representati
 
 use crate::axis;
 
+mod line;
+mod function;
+mod barchart;
+mod boxplot;
+mod histogram;
+mod scatter;
+pub use line::*;
+pub use function::*;
+pub use barchart::*;
+pub use boxplot::*;
+pub use histogram::*;
+pub use scatter::*;
+
 /**
 A representation of data that is continuous in two dimensions.
 */

--- a/src/svg_render.rs
+++ b/src/svg_render.rs
@@ -5,7 +5,7 @@ use svg::Node;
 
 use crate::axis;
 use crate::grid::GridType;
-use crate::histogram;
+use crate::repr;
 use crate::style;
 use crate::utils;
 use crate::utils::PairWise;
@@ -240,7 +240,7 @@ pub fn draw_face_points(
 }
 
 pub fn draw_face_bars(
-    h: &histogram::Histogram,
+    h: &repr::Histogram,
     x_axis: &axis::ContinuousAxis,
     y_axis: &axis::ContinuousAxis,
     face_width: f64,

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -4,7 +4,7 @@ use std;
 use std::collections::HashMap;
 
 use crate::axis;
-use crate::histogram;
+use crate::repr;
 use crate::style;
 use crate::utils::PairWise;
 
@@ -31,7 +31,7 @@ fn tick_offset_map(axis: &axis::ContinuousAxis, face_width: u32) -> HashMap<i32,
 /// and the number of face cells to work with,
 /// create a mapping of cell offset to bin bound
 fn bound_cell_offsets(
-    hist: &histogram::Histogram,
+    hist: &repr::Histogram,
     x_axis: &axis::ContinuousAxis,
     face_width: u32,
 ) -> Vec<i32> {
@@ -271,7 +271,7 @@ pub fn render_x_axis_strings(x_axis: &axis::ContinuousAxis, face_width: u32) -> 
 /// and the face height and width,
 /// create the strings to be drawn as the face
 pub fn render_face_bars(
-    h: &histogram::Histogram,
+    h: &repr::Histogram,
     x_axis: &axis::ContinuousAxis,
     y_axis: &axis::ContinuousAxis,
     face_width: u32,
@@ -591,7 +591,7 @@ mod tests {
     #[test]
     fn test_render_face_bars() {
         let data = vec![0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
-        let h = histogram::Histogram::from_slice(&data, histogram::Bins::Count(10));
+        let h = repr::Histogram::from_slice(&data, repr::HistogramBins::Count(10));
         let x_axis = axis::ContinuousAxis::new(0.3, 7.5);
         let y_axis = axis::ContinuousAxis::new(0., 3.);
         let strings = render_face_bars(&h, &x_axis, &y_axis, 20, 10);
@@ -616,7 +616,7 @@ mod tests {
 
     #[test]
     fn test_render_face_points() {
-        use crate::scatter;
+        use crate::repr;
         use crate::style::PointStyle;
         let data = vec![
             (-3.0, 2.3),
@@ -626,7 +626,7 @@ mod tests {
             (6.4, 4.3),
             (8.5, 3.7),
         ];
-        let s = scatter::Scatter::from_slice(&data);
+        let s = repr::Scatter::from_slice(&data);
         let x_axis = axis::ContinuousAxis::new(-3.575, 9.075);
         let y_axis = axis::ContinuousAxis::new(-1.735, 5.635);
         let style = PointStyle::new();

--- a/src/view.rs
+++ b/src/view.rs
@@ -15,7 +15,7 @@ use svg::Node;
 use crate::axis;
 use crate::errors::Result;
 use crate::grid::{Grid, GridType};
-use crate::representation::{CategoricalRepresentation, ContinuousRepresentation};
+use crate::repr::{CategoricalRepresentation, ContinuousRepresentation};
 use crate::svg_render;
 use crate::text_render;
 

--- a/tests/test_no_data.rs
+++ b/tests/test_no_data.rs
@@ -1,5 +1,5 @@
 use plotlib::page::Page;
-use plotlib::scatter::Scatter;
+use plotlib::repr::Scatter;
 use plotlib::style::{PointMarker, PointStyle};
 use plotlib::view::ContinuousView;
 


### PR DESCRIPTION
All representations are grouped under a new `repr` module. In my opinion, the interface is somewhat simpler because of this logical grouping (and not having to write the module name of each struct), and the grouping adheres better to the "five main components" mentioned in the documentation.

Note that I renamed some structs to be as self-explanatory as possible in `repr`:
* `Marker -> PointMarker`
* `Bins -> HistogramBins`

I like the first one, not sure about the second one. Please tell me your preference and I will change it!

- [x] Add an entry to the CHANGELOG file
- [x] Tests pass, examples compile
- [x] Documentation changed

Builds on #29.