### PR TITLE
Import types from modules in examples

### DIFF
--- a/examples/barchart_svg.rs
+++ b/examples/barchart_svg.rs
@@ -1,15 +1,20 @@
-use plotlib::style::BarChart;
+use plotlib::barchart::{BarChart, Style};
+use plotlib::page::Page;
+// XXX only supports rust 1.31, however we cannot import the BarChart trait and BarChart struct at
+// the same time
+use plotlib::style::BarChart as _;
+use plotlib::view::CategoricalView;
 
 fn main() {
-    let b1 = plotlib::barchart::BarChart::new(5.3).label("1");
-    let b2 = plotlib::barchart::BarChart::new(2.6)
+    let b1 = BarChart::new(5.3).label("1");
+    let b2 = BarChart::new(2.6)
         .label("2")
-        .style(plotlib::barchart::Style::new().fill("darkolivegreen"));
-    let v = plotlib::view::CategoricalView::new()
+        .style(Style::new().fill("darkolivegreen"));
+
+    let v = CategoricalView::new()
         .add(&b1)
         .add(&b2)
         .x_label("Experiment");
-    plotlib::page::Page::single(&v)
-        .save("barchart.svg")
-        .expect("saving svg");
+
+    Page::single(&v).save("barchart.svg").expect("saving svg");
 }

--- a/examples/boxplot_svg.rs
+++ b/examples/boxplot_svg.rs
@@ -1,17 +1,24 @@
-use plotlib::style::BoxPlot;
+use plotlib::boxplot::BoxPlot;
+use plotlib::boxplot::Style;
+use plotlib::page::Page;
+// XXX only supports rust 1.31, however we cannot import the BarChart trait and BarChart struct at
+// the same time
+use plotlib::style::BoxPlot as _;
+use plotlib::view::CategoricalView;
 
 fn main() {
-    let b1 = plotlib::boxplot::BoxPlot::from_slice(&[1.0, 4.0, 2.0, 3.5, 6.4, 2.5, 7.5, 1.8, 9.6])
-        .label("1");
-    let b2 = plotlib::boxplot::BoxPlot::from_slice(&[3.0, 4.3, 2.0, 3.5, 6.9, 4.5, 7.5, 1.8, 10.6])
+    let b1 = BoxPlot::from_slice(&[1.0, 4.0, 2.0, 3.5, 6.4, 2.5, 7.5, 1.8, 9.6]).label("1");
+    let b2 = BoxPlot::from_slice(&[3.0, 4.3, 2.0, 3.5, 6.9, 4.5, 7.5, 1.8, 10.6])
         .label("2")
-        .style(plotlib::boxplot::Style::new().fill("darkolivegreen"));
-    let v = plotlib::view::CategoricalView::new()
+        .style(Style::new().fill("darkolivegreen"));
+
+    let v = CategoricalView::new()
         .add(&b1)
         .add(&b2)
         .x_label("Experiment")
         .y_label("y");
-    plotlib::page::Page::single(&v)
+
+    Page::single(&v)
         .dimensions(400, 300)
         .save("boxplot.svg")
         .expect("saving svg");

--- a/examples/function_svg.rs
+++ b/examples/function_svg.rs
@@ -1,20 +1,16 @@
+use plotlib::function::{Function, Style};
+use plotlib::page::Page;
 use plotlib::style::Line;
+use plotlib::view::ContinuousView;
 
 fn main() {
-    let f1 = plotlib::function::Function::new(|x| x * 5., 0., 10.)
-        .style(plotlib::function::Style::new().colour("burlywood"));
-    let f2 = plotlib::function::Function::new(|x| x.powi(2), 0., 10.).style(
-        plotlib::function::Style::new()
-            .colour("darkolivegreen")
-            .width(2.),
-    );
-    let f3 = plotlib::function::Function::new(|x| x.sqrt() * 20., 0., 10.)
-        .style(plotlib::function::Style::new().colour("brown").width(1.));
-    let v = plotlib::view::ContinuousView::new()
-        .add(&f1)
-        .add(&f2)
-        .add(&f3);
-    plotlib::page::Page::single(&v)
-        .save("function.svg")
-        .expect("saving svg");
+    let f1 = Function::new(|x| x * 5., 0., 10.).style(Style::new().colour("burlywood"));
+    let f2 = Function::new(|x| x.powi(2), 0., 10.)
+        .style(Style::new().colour("darkolivegreen").width(2.));
+    let f3 =
+        Function::new(|x| x.sqrt() * 20., 0., 10.).style(Style::new().colour("brown").width(1.));
+
+    let v = ContinuousView::new().add(&f1).add(&f2).add(&f3);
+
+    Page::single(&v).save("function.svg").expect("saving svg");
 }

--- a/examples/histogram_svg.rs
+++ b/examples/histogram_svg.rs
@@ -1,11 +1,14 @@
+use plotlib::histogram::{Histogram, Style};
+use plotlib::page::Page;
 use plotlib::style::Bar;
+use plotlib::view::ContinuousView;
 
 fn main() {
     let data = [0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
-    let h = plotlib::histogram::Histogram::from_slice(&data, plotlib::histogram::Bins::Count(10))
-        .style(plotlib::histogram::Style::new().fill("burlywood"));
-    let v = plotlib::view::ContinuousView::new().add(&h);
-    plotlib::page::Page::single(&v)
-        .save("histogram.svg")
-        .expect("saving svg");
+    let h = Histogram::from_slice(&data, plotlib::histogram::Bins::Count(10))
+        .style(Style::new().fill("burlywood"));
+
+    let v = ContinuousView::new().add(&h);
+
+    Page::single(&v).save("histogram.svg").expect("saving svg");
 }

--- a/examples/histogram_text.rs
+++ b/examples/histogram_text.rs
@@ -1,12 +1,13 @@
+use plotlib::histogram::{Bins, Histogram};
+use plotlib::page::Page;
+use plotlib::view::ContinuousView;
+
 fn main() {
     let data = [0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
-    let h = plotlib::histogram::Histogram::from_slice(&data, plotlib::histogram::Bins::Count(10));
-    let v = plotlib::view::ContinuousView::new().add(&h);
-    println!(
-        "{}",
-        plotlib::page::Page::single(&v)
-            .dimensions(60, 15)
-            .to_text()
-            .unwrap()
-    );
+
+    let h = Histogram::from_slice(&data, Bins::Count(10));
+
+    let v = ContinuousView::new().add(&h);
+
+    println!("{}", Page::single(&v).dimensions(60, 15).to_text().unwrap());
 }

--- a/examples/line_svg.rs
+++ b/examples/line_svg.rs
@@ -1,10 +1,13 @@
-use plotlib::style::Line;
+use plotlib::line::{Line, Style};
+use plotlib::page::Page;
+// XXX only supports rust 1.31, however we cannot import the BarChart trait and BarChart struct at
+// the same time
+use plotlib::style::Line as _;
+use plotlib::view::ContinuousView;
 
 fn main() {
-    let l1 = plotlib::line::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
-        .style(plotlib::line::Style::new().colour("burlywood"));
-    let v = plotlib::view::ContinuousView::new().add(&l1);
-    plotlib::page::Page::single(&v)
-        .save("line.svg")
-        .expect("saving svg");
+    let l1 = Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
+        .style(Style::new().colour("burlywood"));
+    let v = ContinuousView::new().add(&l1);
+    Page::single(&v).save("line.svg").expect("saving svg");
 }

--- a/examples/scatter_svg.rs
+++ b/examples/scatter_svg.rs
@@ -1,4 +1,7 @@
-use plotlib::style::Point;
+use plotlib::page::Page;
+use plotlib::scatter::{Scatter, Style};
+use plotlib::style::{Marker, Point};
+use plotlib::view::ContinuousView;
 
 fn main() {
     let data = [
@@ -9,83 +12,23 @@ fn main() {
         (6.4, 4.3),
         (8.5, 3.7),
     ];
-    let s1 = plotlib::scatter::Scatter::from_slice(&data).style(
-        plotlib::scatter::Style::new()
-            .marker(plotlib::style::Marker::Square)
+
+    let s1 = Scatter::from_slice(&data).style(
+        Style::new()
+            .marker(Marker::Square)
             .colour("burlywood")
             .size(2.),
     );
-    let s2 = plotlib::scatter::Scatter::from_slice(&[(-1.4, 2.5), (7.2, -0.3)])
-        .style(plotlib::scatter::Style::new().colour("darkseagreen"));
-    let v = plotlib::view::ContinuousView::new()
+    let s2 =
+        Scatter::from_slice(&[(-1.4, 2.5), (7.2, -0.3)]).style(Style::new().colour("darkseagreen"));
+
+    let v = ContinuousView::new()
         .add(&s1)
         .add(&s2)
         .x_range(-5., 10.)
         .y_range(-2., 6.)
         .x_label("Some varying variable")
         .y_label("The response of something");
-    plotlib::page::Page::single(&v)
-        .save("scatter.svg")
-        .expect("saving svg");
 
-    /*
-    //
-    // Create a scatter representation
-    let s = Scatter::new()
-        .data(data)
-        .y_errors(errors)
-        .colour(Colour::Red)
-        .marker(Marker::Circle);
-
-    // Create a histogram representation
-    let h = Histogram::new()
-        .data(data2)
-        .error_bars(true)
-        .fill(Colour::Green);
-
-    // Create a function representation
-    let l = Function::new()
-        .function(|&x| sin(x/100.0))
-        .colour(Colour::Blue);
-        .stroke(Style::Dotted);
-
-    // Create a grid. Maybe this should be part of the view directly?
-    let g = Grid::new();
-
-    // Create a view containing all the representations
-    let v = ContinuousView::new()
-        .add(&l)
-        .add(&h)
-        .add(&s)
-        .add(&g)
-        .x_range(-10, 90)
-        .x_label("Age")
-        );
-
-    // put that view into a plot and save it to file
-    let p = Plot::single(v);
-    p.save("plot.svg");
-
-    //
-    // Copy of http://matplotlib.org/examples/lines_bars_and_markers/fill_demo_features.html
-    let y1 = Function::new()
-        .function(|&x| sin(x))
-        .sampling(Array::linspace(0., 2. * pi, 500))
-        .colour(Colour::Blue);
-        .alpha(0.3)
-        .fill(true);
-
-    let y2 = Function::new()
-        .function(|&x| sin(3 * x))
-        .sampling(Array::linspace(0., 2. * pi, 500))
-        .colour(Colour::Red);
-        .alpha(0.3)
-        .fill(true;
-
-    let v = ContinuousView::new()
-        .add(y1)
-        .add(y2);
-
-    Plot::single(v).save("plot.svg");
-    */
+    Page::single(&v).save("scatter.svg").expect("saving svg");
 }

--- a/examples/scatter_text.rs
+++ b/examples/scatter_text.rs
@@ -1,4 +1,7 @@
-use plotlib::style::Point;
+use plotlib::page::Page;
+use plotlib::scatter::{Scatter, Style};
+use plotlib::style::{Marker, Point};
+use plotlib::view::ContinuousView;
 
 fn main() {
     let data = [
@@ -9,15 +12,18 @@ fn main() {
         (6.4, 4.3),
         (8.5, 3.7),
     ];
-    let s1 = plotlib::scatter::Scatter::from_slice(&data);
-    let s2 = plotlib::scatter::Scatter::from_slice(&[(-1.4, 2.5), (7.2, -0.3)])
-        .style(plotlib::scatter::Style::new().marker(plotlib::style::Marker::Square));
-    let v = plotlib::view::ContinuousView::new()
+
+    let s1 = Scatter::from_slice(&data);
+    let s2 =
+        Scatter::from_slice(&[(-1.4, 2.5), (7.2, -0.3)]).style(Style::new().marker(Marker::Square));
+
+    let v = ContinuousView::new()
         .add(&s1)
         .add(&s2)
         .x_range(-5., 10.)
         .y_range(-2., 6.)
         .x_label("Some varying variable")
         .y_label("The response of something");
-    println!("{}", plotlib::page::Page::single(&v).to_text().unwrap());
+
+    println!("{}", Page::single(&v).to_text().unwrap());
 }

--- a/examples/with_grid.rs
+++ b/examples/with_grid.rs
@@ -1,9 +1,14 @@
-extern crate plotlib;
-
+use plotlib::barchart::BarChart;
+use plotlib::barchart::Style as BarChartStyle;
 use plotlib::grid::Grid;
-use plotlib::style::BarChart;
-use plotlib::style::Line;
-use plotlib::view::View;
+use plotlib::line::Line;
+use plotlib::line::Style as LineStyle;
+use plotlib::page::Page;
+// XXX only supports rust 1.31, however we cannot import the BarChart trait and BarChart struct at
+// the same time
+use plotlib::style::BarChart as _;
+use plotlib::style::Line as _;
+use plotlib::view::{CategoricalView, ContinuousView, View};
 
 fn main() {
     render_line_chart("line_with_grid.svg");
@@ -14,11 +19,11 @@ fn render_line_chart<S>(filename: S)
 where
     S: AsRef<str>,
 {
-    let l1 = plotlib::line::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
-        .style(plotlib::line::Style::new().colour("burlywood"));
-    let mut v = plotlib::view::ContinuousView::new().add(&l1);
+    let l1 = Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
+        .style(LineStyle::new().colour("burlywood"));
+    let mut v = ContinuousView::new().add(&l1);
     v.add_grid(Grid::new(3, 8));
-    plotlib::page::Page::single(&v)
+    Page::single(&v)
         .save(filename.as_ref())
         .expect("saving svg");
 }
@@ -27,16 +32,16 @@ fn render_barchart<S>(filename: S)
 where
     S: AsRef<str>,
 {
-    let b1 = plotlib::barchart::BarChart::new(5.3).label("1");
-    let b2 = plotlib::barchart::BarChart::new(2.6)
+    let b1 = BarChart::new(5.3).label("1");
+    let b2 = BarChart::new(2.6)
         .label("2")
-        .style(plotlib::barchart::Style::new().fill("darkolivegreen"));
-    let mut v = plotlib::view::CategoricalView::new()
+        .style(BarChartStyle::new().fill("darkolivegreen"));
+    let mut v = CategoricalView::new()
         .add(&b1)
         .add(&b2)
         .x_label("Experiment");
     v.add_grid(Grid::new(3, 8));
-    plotlib::page::Page::single(&v)
+    Page::single(&v)
         .save(filename.as_ref())
         .expect("saving svg");
 }


### PR DESCRIPTION
The examples should be a bit simpler, easier to understand. Removing
long nested imports helps to this end.

I don't feel this needs a changelog entry as it does not affect the core library or the way people use it, just the readability