### PR TITLE
Linejoin style

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 ### Changed
 - Remove style traits and replace all style structs with 3 common ones in `style`
 - Group all representations under a `repr` module.
+- Add `linejoin` option to line style.
 
 ## 0.4.0 - 2019-03-02
 ### Added

--- a/src/style.rs
+++ b/src/style.rs
@@ -175,3 +175,25 @@ impl BoxStyle {
         &self.fill
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_linestyle_simple() {
+        let s = LineStyle::new();
+        assert_eq!(*s.get_colour(), None);
+        assert_eq!(*s.get_width(), None);
+        assert_eq!(*s.get_linejoin(), None);
+    }
+
+    #[test]
+    fn test_linestyle_plain_overlay() {
+        let mut p = LineStyle::new();
+        p.overlay(LineStyle::new().colour("red").linejoin("bevel").width(1.));
+        assert_eq!(*p.get_colour(), Some("red".into()));
+        assert_eq!(*p.get_width(), Some(1.));
+        assert_eq!(*p.get_linejoin(), Some("bevel".into()));
+    }
+}

--- a/src/style.rs
+++ b/src/style.rs
@@ -10,12 +10,14 @@
 pub struct LineStyle {
     colour: Option<String>,
     width: Option<f32>,
+    linejoin: Option<String>,
 }
 impl LineStyle {
     pub fn new() -> Self {
         LineStyle {
             colour: None,
             width: None,
+            linejoin: None,
         }
     }
 
@@ -26,6 +28,10 @@ impl LineStyle {
 
         if let Some(ref v) = other.width {
             self.width = Some(*v)
+        }
+
+        if let Some(ref v) = other.linejoin {
+            self.linejoin = Some(v.clone())
         }
     }
     pub fn colour<T>(&mut self, value: T) -> &mut Self
@@ -50,6 +56,18 @@ impl LineStyle {
 
     pub fn get_width(&self) -> &Option<f32> {
         &self.width
+    }
+
+    pub fn linejoin<T>(&mut self, value: T) -> &mut Self
+    where
+        T: Into<String>,
+    {
+        self.linejoin = Some(value.into());
+        self
+    }
+
+    pub fn get_linejoin(&self) -> &Option<String> {
+        &self.linejoin
     }
 }
 

--- a/src/svg_render.rs
+++ b/src/svg_render.rs
@@ -312,6 +312,7 @@ pub fn draw_face_line(
                 style.get_colour().clone().unwrap_or_else(|| "".into()),
             )
             .set("stroke-width", style.get_width().clone().unwrap_or(2.))
+            .set("stroke-linejoin", style.get_linejoin().clone().unwrap_or("round".into()))
             .set("d", path),
     );
 


### PR DESCRIPTION
This fixes #32 by using the `stroke-linejoin` SVG property.