### PR TITLE
Set the dimensions in the scatter_text example

### DIFF
--- a/examples/scatter_text.rs
+++ b/examples/scatter_text.rs
@@ -24,5 +24,5 @@ fn main() {
         .x_label("Some varying variable")
         .y_label("The response of something");
 
-    println!("{}", Page::single(&v).to_text().unwrap());
+    println!("{}", Page::single(&v).dimensions(80, 30).to_text().unwrap());
 }


### PR DESCRIPTION
A minor fix to the example to make it fit on the page. It now looks like:

```
    6-|                                                                               
      |                                                                               
      |                                                                               
 T    |                ●                                                              
 h    |                                                                               
 e    |                                                                               
      |                                                           ●                   
 r  4-|                                                                               
 e    |                                                                               
 s    |                                                                      ●        
 p    |                                                                               
 o    |                                                                               
 n    |                                                                               
 s    |                 ■                                                             
 e    |         ●                                                                     
    2-|                                                                               
 o    |                                                                               
 f    |                                                                               
      |                                                                               
 s    |                                                                               
 o    |                          ●                                                    
 m    |                                                                               
 e  0-|                                                                               
 t    |                                                                               
 h    |                                                               ■               
 i    |                                                                               
 n    |                                                                               
 g    |                                                                               
      |                                                ●                              
      |                                                                               
   -2-+--------------------------------------------------------------------------------
      |                          |                         |                          |
     -5                          0                         5                         10
                                   Some varying variable                              

```