### PR TITLE
Start with legends, and less references

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,14 @@
 # Changelog
 
 ## Unreleased
+### Added
+- Legends for line plots
+
 ### Changed
 - Remove style traits and replace all style structs with 3 common ones in `style`
 - Group all representations under a `repr` module.
 - Add `linejoin` option to line style.
+- More Box and less & in the interface
 
 ## 0.4.0 - 2019-03-02
 ### Added

--- a/examples/barchart_svg.rs
+++ b/examples/barchart_svg.rs
@@ -10,8 +10,8 @@ fn main() {
         .style(BoxStyle::new().fill("darkolivegreen"));
 
     let v = CategoricalView::new()
-        .add(&b1)
-        .add(&b2)
+        .add(b1)
+        .add(b2)
         .x_label("Experiment");
 
     Page::single(&v).save("barchart.svg").expect("saving svg");

--- a/examples/boxplot_svg.rs
+++ b/examples/boxplot_svg.rs
@@ -10,8 +10,8 @@ fn main() {
         .style(BoxStyle::new().fill("darkolivegreen"));
 
     let v = CategoricalView::new()
-        .add(&b1)
-        .add(&b2)
+        .add(b1)
+        .add(b2)
         .x_label("Experiment")
         .y_label("y");
 

--- a/examples/function_svg.rs
+++ b/examples/function_svg.rs
@@ -10,7 +10,7 @@ fn main() {
     let f3 = Function::new(|x| x.sqrt() * 20., 0., 10.)
         .style(LineStyle::new().colour("brown").width(1.));
 
-    let v = ContinuousView::new().add(&f1).add(&f2).add(&f3);
+    let v = ContinuousView::new().add(f1).add(f2).add(f3);
 
     Page::single(&v).save("function.svg").expect("saving svg");
 }

--- a/examples/histogram_svg.rs
+++ b/examples/histogram_svg.rs
@@ -8,7 +8,7 @@ fn main() {
     let h = Histogram::from_slice(&data, HistogramBins::Count(10))
         .style(BoxStyle::new().fill("burlywood"));
 
-    let v = ContinuousView::new().add(&h);
+    let v = ContinuousView::new().add(h);
 
     Page::single(&v).save("histogram.svg").expect("saving svg");
 }

--- a/examples/histogram_text.rs
+++ b/examples/histogram_text.rs
@@ -6,7 +6,7 @@ fn main() {
     let data = [0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
     let h = Histogram::from_slice(&data, HistogramBins::Count(10));
 
-    let v = ContinuousView::new().add(&h);
+    let v = ContinuousView::new().add(h);
 
     println!("{}", Page::single(&v).dimensions(60, 15).to_text().unwrap());
 }

--- a/examples/line_svg.rs
+++ b/examples/line_svg.rs
@@ -4,11 +4,11 @@ use plotlib::style::{LineJoin, LineStyle};
 use plotlib::view::ContinuousView;
 
 fn main() {
-    let l1 = Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)]).style(
+    let l1 = Line::new(vec![(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)]).style(
         LineStyle::new()
             .colour("burlywood")
             .linejoin(LineJoin::Round),
     );
-    let v = ContinuousView::new().add(&l1);
+    let v = ContinuousView::new().add(l1);
     Page::single(&v).save("line.svg").expect("saving svg");
 }

--- a/examples/scatter_svg.rs
+++ b/examples/scatter_svg.rs
@@ -22,8 +22,8 @@ fn main() {
         .style(PointStyle::new().colour("darkseagreen"));
 
     let v = ContinuousView::new()
-        .add(&s1)
-        .add(&s2)
+        .add(s1)
+        .add(s2)
         .x_range(-5., 10.)
         .y_range(-2., 6.)
         .x_label("Some varying variable")

--- a/examples/scatter_text.rs
+++ b/examples/scatter_text.rs
@@ -17,8 +17,8 @@ fn main() {
         .style(PointStyle::new().marker(PointMarker::Square));
 
     let v = ContinuousView::new()
-        .add(&s1)
-        .add(&s2)
+        .add(s1)
+        .add(s2)
         .x_range(-5., 10.)
         .y_range(-2., 6.)
         .x_label("Some varying variable")

--- a/examples/with_grid.rs
+++ b/examples/with_grid.rs
@@ -13,9 +13,9 @@ fn render_line_chart<S>(filename: S)
 where
     S: AsRef<str>,
 {
-    let l1 = Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
+    let l1 = Line::new(vec![(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
         .style(LineStyle::new().colour("burlywood"));
-    let mut v = ContinuousView::new().add(&l1);
+    let mut v = ContinuousView::new().add(l1);
     v.add_grid(Grid::new(3, 8));
     Page::single(&v)
         .save(filename.as_ref())
@@ -31,8 +31,8 @@ where
         .label("2")
         .style(BoxStyle::new().fill("darkolivegreen"));
     let mut v = CategoricalView::new()
-        .add(&b1)
-        .add(&b2)
+        .add(b1)
+        .add(b2)
         .x_label("Experiment");
     v.add_grid(Grid::new(3, 8));
     Page::single(&v)

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -29,11 +29,10 @@ pub struct ContinuousAxis {
 
 impl ContinuousAxis {
     /// Constructs a new ContinuousAxis
-    pub fn new(lower: f64, upper: f64) -> ContinuousAxis {
-        let default_max_ticks = 6;
+    pub fn new(lower: f64, upper: f64, max_ticks: usize) -> ContinuousAxis {
         ContinuousAxis {
             range: Range::new(lower, upper),
-            ticks: calculate_ticks(lower, upper, default_max_ticks),
+            ticks: calculate_ticks(lower, upper, max_ticks),
             label: "".into(),
         }
     }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -18,10 +18,10 @@
 //! # use plotlib::style::LineStyle;
 //! # use plotlib::view::View;
 //!
-//! # let l1 = plotlib::repr::Line::new(&[(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
+//! # let l1 = plotlib::repr::Line::new(vec![(0., 1.), (2., 1.5), (3., 1.2), (4., 1.1)])
 //! #    .style(LineStyle::new().colour("burlywood"));
 //! // let l1 = Line::new() ...
-//! let mut v = ContinuousView::new().add(&l1);
+//! let mut v = ContinuousView::new().add(l1);
 //!
 //! // 3 vertical lines and 8 horizontal lines
 //! v.add_grid(Grid::new(3, 8));

--- a/src/repr/barchart.rs
+++ b/src/repr/barchart.rs
@@ -9,7 +9,7 @@ Bar chart
 # use plotlib::view::CategoricalView;
 let b1 = BarChart::new(5.2).label("b1");
 let b2 = BarChart::new(1.6).label("b2");
-let v = CategoricalView::new().add(&b1).add(&b2);
+let v = CategoricalView::new().add(b1).add(b2);
 ```
 */
 

--- a/src/repr/boxplot.rs
+++ b/src/repr/boxplot.rs
@@ -9,7 +9,7 @@ Box plot
 # use plotlib::view::CategoricalView;
 let b1 = BoxPlot::from_slice(&[0., 2., 3., 4.]);
 let b2 = BoxPlot::from_vec(vec![0., 2., 3., 4.]);
-let v = CategoricalView::new().add(&b1);
+let v = CategoricalView::new().add(b1);
 ```
 */
 

--- a/src/repr/function.rs
+++ b/src/repr/function.rs
@@ -9,7 +9,7 @@ Plot arbitrary functions
 # use plotlib::view::ContinuousView;
 // y=x^2 between 0 and 10
 let f = Function::new(|x| x*x, 0., 10.);
-let v = ContinuousView::new().add(&f);
+let v = ContinuousView::new().add(f);
 ```
 */
 
@@ -97,6 +97,11 @@ impl ContinuousRepresentation for Function {
             face_height,
             &self.style,
         )
+    }
+
+    fn legend_svg(&self) -> Option<svg::node::element::Group> {
+        // TODO implement
+        None
     }
 
     fn to_text(

--- a/src/repr/histogram.rs
+++ b/src/repr/histogram.rs
@@ -165,6 +165,10 @@ impl ContinuousRepresentation for Histogram {
     ) -> svg::node::element::Group {
         svg_render::draw_face_bars(self, x_axis, y_axis, face_width, face_height, &self.style)
     }
+    fn legend_svg(&self) -> Option<svg::node::element::Group> {
+        // TODO implement
+        None
+    }
 
     fn to_text(
         &self,

--- a/src/repr/mod.rs
+++ b/src/repr/mod.rs
@@ -42,6 +42,9 @@ pub trait ContinuousRepresentation {
         face_height: f64,
     ) -> svg::node::element::Group;
 
+    /// Returns None if no legend has been specified for this representation
+    fn legend_svg(&self) -> Option<svg::node::element::Group>;
+
     fn to_text(
         &self,
         x_axis: &axis::ContinuousAxis,

--- a/src/repr/scatter.rs
+++ b/src/repr/scatter.rs
@@ -84,6 +84,10 @@ impl ContinuousRepresentation for Scatter {
             &self.style,
         )
     }
+    fn legend_svg(&self) -> Option<svg::node::element::Group> {
+        // TODO implement
+        None
+    }
 
     fn to_text(
         &self,

--- a/src/svg_render.rs
+++ b/src/svg_render.rs
@@ -491,7 +491,7 @@ mod tests {
 
     #[test]
     fn test_value_to_face_offset() {
-        let axis = axis::ContinuousAxis::new(-2., 5.);
+        let axis = axis::ContinuousAxis::new(-2., 5., 6);
         assert_eq!(value_to_face_offset(-2.0, &axis, 14.0), 0.0);
         assert_eq!(value_to_face_offset(5.0, &axis, 14.0), 14.0);
         assert_eq!(value_to_face_offset(0.0, &axis, 14.0), 4.0);

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -523,7 +523,7 @@ mod tests {
     #[test]
     fn test_value_to_axis_cell_offset() {
         assert_eq!(
-            value_to_axis_cell_offset(3.0, &axis::ContinuousAxis::new(5.0, 10.0), 10),
+            value_to_axis_cell_offset(3.0, &axis::ContinuousAxis::new(5.0, 10.0, 6), 10),
             -4
         );
     }
@@ -565,7 +565,7 @@ mod tests {
 
     #[test]
     fn test_render_y_axis_strings() {
-        let y_axis = axis::ContinuousAxis::new(0.0, 10.0);
+        let y_axis = axis::ContinuousAxis::new(0.0, 10.0, 6);
 
         let (y_axis_string, longest_y_label_width) = render_y_axis_strings(&y_axis, 10);
 
@@ -577,7 +577,7 @@ mod tests {
 
     #[test]
     fn test_render_x_axis_strings() {
-        let x_axis = axis::ContinuousAxis::new(0.0, 10.0);
+        let x_axis = axis::ContinuousAxis::new(0.0, 10.0, 6);
 
         let (x_axis_string, start_offset) = render_x_axis_strings(&x_axis, 20);
 
@@ -592,8 +592,8 @@ mod tests {
     fn test_render_face_bars() {
         let data = vec![0.3, 0.5, 6.4, 5.3, 3.6, 3.6, 3.5, 7.5, 4.0];
         let h = repr::Histogram::from_slice(&data, repr::HistogramBins::Count(10));
-        let x_axis = axis::ContinuousAxis::new(0.3, 7.5);
-        let y_axis = axis::ContinuousAxis::new(0., 3.);
+        let x_axis = axis::ContinuousAxis::new(0.3, 7.5, 6);
+        let y_axis = axis::ContinuousAxis::new(0., 3., 6);
         let strings = render_face_bars(&h, &x_axis, &y_axis, 20, 10);
         assert_eq!(strings.lines().count(), 10);
         assert!(strings.lines().all(|s| s.chars().count() == 20));
@@ -627,8 +627,8 @@ mod tests {
             (8.5, 3.7),
         ];
         let s = repr::Scatter::from_slice(&data);
-        let x_axis = axis::ContinuousAxis::new(-3.575, 9.075);
-        let y_axis = axis::ContinuousAxis::new(-1.735, 5.635);
+        let x_axis = axis::ContinuousAxis::new(-3.575, 9.075, 6);
+        let y_axis = axis::ContinuousAxis::new(-1.735, 5.635, 6);
         let style = PointStyle::new();
         let strings = render_face_points(&s.data, &x_axis, &y_axis, 20, 10, &style);
         assert_eq!(strings.lines().count(), 10);

--- a/tests/test_no_data.rs
+++ b/tests/test_no_data.rs
@@ -17,7 +17,7 @@ fn test_data_with_one_length() {
 
     // The 'view' describes what set of data is drawn
     let v = ContinuousView::new()
-        .add(&s1)
+        .add(s1)
         .x_range(-5., 10.)
         .y_range(-2., 6.)
         .x_label("Some varying variable")
@@ -43,7 +43,7 @@ fn test_data_with_no_length() {
 
     // The 'view' describes what set of data is drawn
     let v = ContinuousView::new()
-        .add(&s1)
+        .add(s1)
         .x_range(-5., 10.)
         .y_range(-2., 6.)
         .x_label("Some varying variable")
@@ -70,7 +70,7 @@ fn test_data_with_one_length_and_autoscaling_axes_limits() {
 
     // The 'view' describes what set of data is drawn
     let v = ContinuousView::new()
-        .add(&s1)
+        .add(s1)
         .x_label("Some varying variable")
         .y_label("The response of something");
 


### PR DESCRIPTION
I am planning to work on the ideas in #34 and I had some changes in plotlib so I thought it could be a good idea to do a PR with those changes now, so that the next PR which builds on these changes is easier to read.

First and foremost I started implementing legends.
Notice that this is only implemented for Line so far. But in the following PR it will be implemented for Function and Scatter as well.

Secondly, I removed some `&` and replaced them with `Box` - better interface.

And also give the programmer possibility to specify max number of x and y ticks.