### PR TITLE
Allow building Scatter directly from an external Vec<(f64,f64)>

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 - Group all representations under a `repr` module.
 - Add `linejoin` option to line style.
 - More Box and less & in the interface
+- Add from_vec to Scatter, makes all Scatter fields public
 
 ## 0.4.0 - 2019-03-02
 ### Added

--- a/src/repr/scatter.rs
+++ b/src/repr/scatter.rs
@@ -13,7 +13,7 @@ use crate::text_render;
 #[derive(Debug)]
 pub struct Scatter {
     pub data: Vec<(f64, f64)>,
-    style: PointStyle,
+    pub style: PointStyle,
 }
 
 impl Scatter {
@@ -26,6 +26,13 @@ impl Scatter {
         Scatter {
             data,
             style: PointStyle::new(),
+        }
+    }
+
+    pub fn from_vec(v: Vec<(f64,f64)>) -> Self {
+        Scatter {
+            data: v,
+            style: PointStyle::new()
         }
     }
 

--- a/src/repr/scatter.rs
+++ b/src/repr/scatter.rs
@@ -10,7 +10,7 @@ use crate::text_render;
 
 /// The scatter *representation*.
 /// It knows its data as well how to style itself
-#[derive(Debug)]
+#[derive(Debug,Clone)]
 pub struct Scatter {
     pub data: Vec<(f64, f64)>,
     pub style: PointStyle,

--- a/src/style.rs
+++ b/src/style.rs
@@ -91,7 +91,7 @@ pub enum PointMarker {
 }
 
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default,Clone)]
 pub struct PointStyle {
     marker: Option<PointMarker>,
     colour: Option<String>,

--- a/src/view.rs
+++ b/src/view.rs
@@ -29,14 +29,14 @@ pub trait View {
 /// Standard 1-dimensional view with a continuous x-axis
 #[derive(Default)]
 pub struct ContinuousView {
-    representations: Vec<Box<dyn ContinuousRepresentation>>,
-    x_range: Option<axis::Range>,
-    y_range: Option<axis::Range>,
-    x_max_ticks: usize,
-    y_max_ticks: usize,
-    x_label: Option<String>,
-    y_label: Option<String>,
-    grid: Option<Grid>,
+    pub representations: Vec<Box<dyn ContinuousRepresentation>>,
+    pub x_range: Option<axis::Range>,
+    pub y_range: Option<axis::Range>,
+    pub x_max_ticks: usize,
+    pub y_max_ticks: usize,
+    pub x_label: Option<String>,
+    pub y_label: Option<String>,
+    pub grid: Option<Grid>,
 }
 
 impl ContinuousView {


### PR DESCRIPTION
This pull request looks to make plotting data represented as an external vector of `(f64,f64)` tuples more ergonomic to deal with, which helps with representing external data with this library. For example, if we create a vector of points (or, for example, if a 2D column of values was imported from a `.csv` file), it's possible to build a Scatter structure to be represented in the ContinuousView directly by providing a vector of those tuples and a `style`. Since `style` was previously a private field, it wasn't able to be directly modified, and using the `from_slice` method was more or less required, preventing representation of any data whose size isn't known at compile-time. 

```rust
let mut data3: Vec<(f64,f64)> = vec![(-2.6, -2.7),(2.0,1.0)];
let s3: Scatter = Scatter {data: data3, style: PointStyle::new() }.style(
    PointStyle::new() // uses the default marker
    .colour("red"),
);
```
A `from_vec()` function helps to make this a little bit more easier to do, provided that the PointStyle is defined after the initial Scatter is built (I believe it defaults to not being represented, unless the style is directly modified). 
```rust
let mut s3: Scatter = Scatter::from_vec(data3);
s3.style.colour("red");
```

I'm happy to make any modifications that might better fit with your preferences or standards for pull requests, and/or to discuss if this is the best way to accomplish making it easier to plot data in this form. Thanks for your time!
