### PR TITLE
display the markers in the svg lengend of scatter plots

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## Unreleased - 2020-05-06
+- Added the following point markers Plus, Star, Triangle, TriangleDown, Diamond.
+
+## Unreleased - 2020-04-07
 - Show markers in the line/scatter plots legend.
 - Minor refactor in `svg_render` to factor out the logic to draw point styles.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Show markers in the line/scatter plots legend.
+- Minor refactor in `svg_render` to factor out the logic to draw point styles.
 
 ## 0.5.1 - 2020-03-28
 ### Fixed

--- a/src/page.rs
+++ b/src/page.rs
@@ -100,10 +100,19 @@ impl<'a> Page<'a> {
     where
         P: AsRef<Path>,
     {
-        match path.as_ref().extension().and_then(OsStr::to_str) {
-            Some("svg") => svg::save(path, &self.to_svg()?)
-                .context("saving svg")
-                .map_err(From::from),
+        let path = path.as_ref();
+        match path.extension().and_then(OsStr::to_str) {
+            Some("svg") => {
+                if let Some(parent) = path.parent() {
+                    if !parent.exists() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+                }
+
+                svg::save(&path, &self.to_svg()?)
+                    .context("saving svg")
+                    .map_err(From::from)
+            },
             _ => Ok(()),
         }
     }

--- a/src/repr/plot.rs
+++ b/src/repr/plot.rs
@@ -147,7 +147,7 @@ impl ContinuousRepresentation for Plot {
             let legend = legend.clone();
 
             let mut group = node::element::Group::new();
-            const FONT_SIZE: f32 = 12.0;
+            const FONT_SIZE: f32 = 9.0;
 
             // Draw legend text
             let legend_text = node::element::Text::new()

--- a/src/repr/plot.rs
+++ b/src/repr/plot.rs
@@ -21,6 +21,7 @@ use crate::repr::ContinuousRepresentation;
 use crate::style::*;
 use crate::svg_render;
 use crate::text_render;
+use crate::svg_render::draw_marker;
 
 /// Representation of any plot with points in the XY plane, visualized as points and/or with lines
 /// in-between.
@@ -159,13 +160,18 @@ impl ContinuousRepresentation for Plot {
 
             if let Some(ref style) = self.line_style {
                 let line = node::element::Line::new()
-                    .set("x1", -10)
+                    .set("x1", -23)
                     .set("y1", -FONT_SIZE / 2. + 2.)
                     .set("x2", -3)
                     .set("y2", -FONT_SIZE / 2. + 2.)
                     .set("stroke-width", style.get_width())
                     .set("stroke", style.get_colour());
                 group.append(line);
+            }
+
+            if let Some(ref style) = self.point_style {
+                let mark = draw_marker(-13., (-FONT_SIZE / 2. + 2.) as f64, style);
+                group.append(mark);
             }
 
             group

--- a/src/style.rs
+++ b/src/style.rs
@@ -60,7 +60,7 @@ impl LineStyle {
         self
     }
     pub fn get_width(&self) -> f32 {
-        self.width.unwrap_or_else(|| 2.0)
+        self.width.unwrap_or_else(|| 1.0)
     }
 
     pub fn linejoin<T>(mut self, value: T) -> Self
@@ -81,6 +81,11 @@ pub enum PointMarker {
     Circle,
     Square,
     Cross,
+    Plus,
+    Star,
+    Triangle,
+    TriangleDown,
+    Diamond
 }
 
 #[derive(Debug, Default, Clone)]
@@ -141,7 +146,7 @@ impl PointStyle {
         self
     }
     pub fn get_size(&self) -> f32 {
-        self.size.unwrap_or(5.0)
+        self.size.unwrap_or(3.0)
     }
 }
 

--- a/src/svg_render.rs
+++ b/src/svg_render.rs
@@ -164,19 +164,25 @@ pub fn draw_categorical_x_axis(a: &axis::CategoricalAxis, face_width: f64) -> no
         ticks.append(tick_mark);
 
         let tick_label = node::element::Text::new()
-            .set("x", tick_pos)
-            .set("y", 20)
             .set("text-anchor", "middle")
-            .set("font-size", 12)
+            .set("x", 0)
+            .set("y", 0)
+            .set("font-size", 9)
+            .set("transform", "rotate(10)")
             .add(node::Text::new(tick.to_owned()));
-        labels.append(tick_label);
+
+        let tick_g = node::element::Group::new()
+            .set("transform", format!("translate({}, {})", tick_pos, 20))
+            .add(tick_label);
+
+        labels.append(tick_g);
     }
 
     let label = node::element::Text::new()
         .set("x", face_width / 2.)
         .set("y", 30)
         .set("text-anchor", "middle")
-        .set("font-size", 12)
+        .set("font-size", 9)
         .add(node::Text::new(a.get_label()));
 
     node::element::Group::new()

--- a/src/svg_render.rs
+++ b/src/svg_render.rs
@@ -230,20 +230,133 @@ pub fn draw_marker(x_pos: f64, y_pos: f64, style: &style::PointStyle) -> node::e
             );
         }
         style::PointMarker::Cross => {
-            let path = node::element::path::Data::new()
-                .move_to((x_pos - radius, y_pos - radius))
-                .line_by((radius * 2., radius * 2.))
-                .move_by((-radius * 2., 0))
-                .line_by((radius * 2., -radius * 2.))
+            let data = node::element::path::Data::new()
+                .move_to((-radius, -radius))
+                .line_to(( radius,  radius))
+                .move_to((-radius,  radius))
+                .line_to(( radius, -radius))
                 .close();
-            group.append(
-                node::element::Path::new()
-                    .set("fill", "none")
-                    .set("stroke", style.get_colour())
-                    .set("stroke-width", 2)
-                    .set("d", path),
-            );
+
+            let path = node::element::Path::new()
+                .set("fill", "none")
+                .set("stroke", style.get_colour())
+                .set("stroke-width", 1)
+                .set("d", data);
+
+            let mut translation = node::element::Group::new()
+                .set("transform", format!("translate({},{})", x_pos, y_pos));
+            translation.append(path);
+
+            let mut wrap = node::element::Group::new();
+            wrap.append(translation);
+
+            group.append(wrap);
         }
+        style::PointMarker::Plus => {
+            let data = node::element::path::Data::new()
+                .move_to((-radius, 0))
+                .horizontal_line_to(radius)
+                .move_to((0, - radius))
+                .vertical_line_to(radius)
+                .close();
+
+            let path = node::element::Path::new()
+                .set("fill", "none")
+                .set("stroke", style.get_colour())
+                .set("stroke-width", 1)
+                .set("d", data);
+
+            let mut translation = node::element::Group::new()
+                .set("transform", format!("translate({},{})", x_pos, y_pos));
+            translation.append(path);
+
+            let mut wrap = node::element::Group::new();
+            wrap.append(translation);
+
+            group.append(wrap);
+        }
+        style::PointMarker::Star => {
+            let data = node::element::path::Data::new()
+                .move_to((-radius, 0))
+                .horizontal_line_to(radius)
+                .move_to((0, - radius))
+                .vertical_line_to(radius)
+                .move_to((-radius, -radius))
+                .line_to(( radius,  radius))
+                .move_to((-radius,  radius))
+                .line_to(( radius, -radius))
+                .close();
+
+            let path = node::element::Path::new()
+                .set("fill", "none")
+                .set("stroke", style.get_colour())
+                .set("stroke-width", 1)
+                .set("d", data);
+
+            let mut translation = node::element::Group::new()
+                .set("transform", format!("translate({},{})", x_pos, y_pos));
+            translation.append(path);
+
+            let mut wrap = node::element::Group::new();
+            wrap.append(translation);
+
+            group.append(wrap);
+        }
+        style::PointMarker::Triangle => {
+            let left = (-radius, 0.);
+            let right= ( radius, 0.);
+            let top  = (     0.,  -2.*radius);
+
+            let points = format!("{},{} {},{} {},{}",
+                                 left.0 ,left.1,
+                                 right.0,right.1,
+                                 top.0, top.1);
+
+            let polygon= node::element::Polygon::new()
+                .set("points", points)
+                .set("fill", style.get_colour())
+                .set("transform", format!("translate({},{})", x_pos, y_pos +radius));
+
+            let mut translation = node::element::Group::new();
+            translation.append(polygon);
+
+            group.append(translation);
+        },
+        style::PointMarker::TriangleDown => {
+            let left = (-radius, 0.);
+            let right= ( radius, 0.);
+            let top  = (     0.,  2.*radius);
+
+            let points = format!("{},{} {},{} {},{}",
+                                 left.0 ,left.1,
+                                 right.0,right.1,
+                                 top.0, top.1);
+
+            let polygon= node::element::Polygon::new()
+                .set("points", points)
+                .set("fill", style.get_colour())
+                .set("transform", format!("translate({},{})", x_pos, y_pos -radius));
+
+            let mut translation = node::element::Group::new();
+            translation.append(polygon);
+
+            group.append(translation);
+        },
+        style::PointMarker::Diamond => {
+            let r = radius;
+            let points = format!("{},{} {},{} {},{} {},{}", -r,0, 0,r, r,0, 0,-r);
+            let polygon= node::element::Polygon::new()
+                .set("x", x_pos - radius)
+                .set("y", y_pos - radius)
+                .set("points", points)
+                .set("fill", style.get_colour())
+                .set("transform", format!("translate({},{})", x_pos, y_pos));
+
+            let mut translation = node::element::Group::new();
+            translation.append(polygon);
+
+            group.append(translation);
+        },
     };
     group
 }

--- a/src/svg_render.rs
+++ b/src/svg_render.rs
@@ -199,45 +199,52 @@ pub fn draw_face_points(
     for &(x, y) in s {
         let x_pos = value_to_face_offset(x, x_axis, face_width);
         let y_pos = -value_to_face_offset(y, y_axis, face_height);
-        let radius = f64::from(style.get_size());
-        match style.get_marker() {
-            style::PointMarker::Circle => {
-                group.append(
-                    node::element::Circle::new()
-                        .set("cx", x_pos)
-                        .set("cy", y_pos)
-                        .set("r", radius)
-                        .set("fill", style.get_colour()),
-                );
-            }
-            style::PointMarker::Square => {
-                group.append(
-                    node::element::Rectangle::new()
-                        .set("x", x_pos - radius)
-                        .set("y", y_pos - radius)
-                        .set("width", 2. * radius)
-                        .set("height", 2. * radius)
-                        .set("fill", style.get_colour()),
-                );
-            }
-            style::PointMarker::Cross => {
-                let path = node::element::path::Data::new()
-                    .move_to((x_pos - radius, y_pos - radius))
-                    .line_by((radius * 2., radius * 2.))
-                    .move_by((-radius * 2., 0))
-                    .line_by((radius * 2., -radius * 2.))
-                    .close();
-                group.append(
-                    node::element::Path::new()
-                        .set("fill", "none")
-                        .set("stroke", style.get_colour())
-                        .set("stroke-width", 2)
-                        .set("d", path),
-                );
-            }
-        };
+        let mark = draw_marker(x_pos, y_pos, style);
+        group.append(mark);
     }
 
+    group
+}
+
+pub fn draw_marker(x_pos: f64, y_pos: f64, style: &style::PointStyle) -> node::element::Group  {
+    let radius = f64::from(style.get_size());
+    let mut group = node::element::Group::new();
+    match style.get_marker() {
+        style::PointMarker::Circle => {
+            group.append(
+                node::element::Circle::new()
+                    .set("cx", x_pos)
+                    .set("cy", y_pos)
+                    .set("r", radius)
+                    .set("fill", style.get_colour()),
+            );
+        }
+        style::PointMarker::Square => {
+            group.append(
+                node::element::Rectangle::new()
+                    .set("x", x_pos - radius)
+                    .set("y", y_pos - radius)
+                    .set("width", 2. * radius)
+                    .set("height", 2. * radius)
+                    .set("fill", style.get_colour()),
+            );
+        }
+        style::PointMarker::Cross => {
+            let path = node::element::path::Data::new()
+                .move_to((x_pos - radius, y_pos - radius))
+                .line_by((radius * 2., radius * 2.))
+                .move_by((-radius * 2., 0))
+                .line_by((radius * 2., -radius * 2.))
+                .close();
+            group.append(
+                node::element::Path::new()
+                    .set("fill", "none")
+                    .set("stroke", style.get_colour())
+                    .set("stroke-width", 2)
+                    .set("d", path),
+            );
+        }
+    };
     group
 }
 

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -371,6 +371,11 @@ pub fn render_face_points(
         style::PointMarker::Circle => '●',
         style::PointMarker::Square => '■',
         style::PointMarker::Cross => '×',
+        style::PointMarker::Plus => '+',
+        style::PointMarker::Star => '*',
+        style::PointMarker::Triangle => '▲',
+        style::PointMarker::TriangleDown => '▼',
+        style::PointMarker::Diamond => '♦',
     };
 
     let mut face_strings: Vec<String> = vec![];

--- a/src/view.rs
+++ b/src/view.rs
@@ -167,7 +167,7 @@ impl View for ContinuousView {
 
         let (x_axis, y_axis) = self.create_axes()?;
 
-        let (legend_x, mut legend_y) = (face_width - 100., -face_height);
+        let (legend_x, mut legend_y) = (face_width - 100., -23.);
         if let Some(grid) = &self.grid {
             view_group.append(svg_render::draw_grid(
                 GridType::Both(grid),
@@ -186,7 +186,7 @@ impl View for ContinuousView {
                     "transform",
                     format!("translate({}, {})", legend_x, legend_y),
                 ));
-                legend_y += 18.;
+                legend_y -= 18.;
             }
         }
 


### PR DESCRIPTION
I just adapted the plot to svg logic to show the point marks in the svg legend.

In my case, I find it useful to compare the evolution of upper and lower bounds of several runs of my solver with different config. This way I have one line style per config and one marker for upper/lower bounds. With this fix, my graphs are perfectly legible. Before that, I had to know what line corresponded to what data (this is easy) and the legend displayed two indistinguishable entries with different labels (I could still understand my graphs but it was problematic).